### PR TITLE
Enforce square dimensions for DEM

### DIFF
--- a/dem_stitcher/stitcher.py
+++ b/dem_stitcher/stitcher.py
@@ -7,6 +7,10 @@ import geopandas as gpd
 import numpy as np
 import rasterio
 # from rasterio.warp import Resampling
+####
+from rasterio.warp import reproject
+from rasterio.warp import aligned_target
+######
 from rasterio.crs import CRS
 from rasterio.enums import Resampling
 from rasterio.merge import merge
@@ -94,10 +98,26 @@ def merge_tiles(datasets: List[rasterio.DatasetReader],
                                          dtype='float32',
                                          target_aligned_pixels=True,
                                          #force square pixel w.r.t longitude
-                                         res=datasets[0].res[-1]
+                                         #res=datasets[0].res[-1]
                                          )
-    merged_arr = merged_arr[0, ...]
+    # reshape to square pixels, if necessary
+    if datasets[0].res[0] != datasets[0].res[1]:
+        new_transform, new_width, new_height = aligned_target(merged_transform,
+                                         merged_arr.shape[2],
+                                         merged_arr.shape[1],
+                                         datasets[0].res[-1])
+        dst_arr = np.empty((1, new_height, new_width), dtype='float32')
+        merged_arr, merged_transform = reproject(merged_arr,
+                                        dst_arr,
+                                        src_crs=CRS.from_epsg(4269),
+                                        dst_crs=CRS.from_epsg(4269),
+                                        src_transform=merged_transform,
+                                        dst_transform=new_transform,
+                                        resampling=Resampling[resampling],
+                                        dst_resolution=datasets[0].res[-1]
+                                        )
 
+    merged_arr = merged_arr[0, ...]
     profile = datasets[0].profile.copy()
     profile['height'] = merged_arr.shape[0]
     profile['width'] = merged_arr.shape[1]

--- a/dem_stitcher/stitcher.py
+++ b/dem_stitcher/stitcher.py
@@ -93,6 +93,8 @@ def merge_tiles(datasets: List[rasterio.DatasetReader],
                                          nodata=nodata,
                                          dtype='float32',
                                          target_aligned_pixels=True,
+                                         #force square pixel w.r.t longitude
+                                         res=datasets[0].res[-1]
                                          )
     merged_arr = merged_arr[0, ...]
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,24 +4,25 @@ channels:
  - anaconda
  - defaults
 dependencies:
+- gdal
+- rasterio
+- affine
+- Fiona
+- geopandas
+- matplotlib
+- numpy
+- pandas
+- rasterio
+- Shapely
+- tqdm
+- notebook
+- requests
+- boto3
+- flake8-import-order
+- flake8-blind-except
+- flake8-builtins
+- setuptools
+- setuptools_scm
+- wheel
+- pytest
 - pip
-- pip:
-  - affine>=2.3.0
-  - Fiona>=1.8.6
-  - geopandas>=0.5.1
-  - numpy>=1.17.2
-  - pandas>=0.25.1
-  - rasterio>=1.0.28
-  - Shapely>=1.6.4
-  - matplotlib
-  - tqdm>=4.32.2
-  - notebook
-  - requests
-  - boto3
-  - flake8-import-order
-  - flake8-blind-except
-  - flake8-builtins
-  - setuptools
-  - setuptools_scm
-  - wheel
-  - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -7,13 +7,12 @@ dependencies:
 - gdal
 - rasterio
 - affine
-- Fiona
+- fiona
 - geopandas
 - matplotlib
 - numpy
 - pandas
-- rasterio
-- Shapely
+- shapely
 - tqdm
 - notebook
 - requests


### PR DESCRIPTION
This PR enforces square dimensions for DEM pixels, which before were distorted along polar regions.

This had downstream consequences as Aleutian Island case study GUNW product layers have inconsistent dimensions vis-à-vis metadata layer. Namely, the former do not possess square pixels, with the latitudinal dimension being multiple times larger:
```
Data axis to CRS axis mapping: 2,1
Origin = (-169.004166666666663,54.004166666666670)
Pixel Size = (0.000416666666667,-0.000277777777778)
```

This behavior is not replicated over study areas further to the south (e.g. CA case study), which suggests this is related to/inherited from the DEM itself, which is distorted along the latitudinal axis towards the poles akin to the output product layer pixel dimensions for the Aleutian Island GUNWs.

I tracked down in the DEM stitcher where we may enforce square pixel dimensions to the DEM, which will impose square pixel dimensions downstream for GUNW product layers:
```
Data axis to CRS axis mapping: 2,1
Origin = (-169.004166666666663,54.004166666666670)
Pixel Size = (0.000277777777778,-0.000277777777778)
```

I had tested this bug-fix by using the DEM staging notebook (https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/blob/dev/notebooks/Staging_a_DEM_for_ISCE2.ipynb)