### PR TITLE
v2.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,6 @@ tests/notebooks/
 !notebooks/analysis_and_comparison/0_Alignment_with_original_DEM_tiles.ipynb
 !notebooks/analysis_and_comparison/1_Comparison_with_ISCE2_dem.ipynb
 !notebooks/Filling_in_missing_glo-30_tiles_with_glo-90_tiles.ipynb
+!notebooks/Merging_DEM_Tiles_into_a_VRT.ipynb
 
 notebooks/analysis_and_comparison/la_test/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1]
+
+### Added
+- The function `get_dem_tile_paths` to extract urls or local paths to dem tiles specifying bounds and dem names.
+- Notebook illustrating how to create a `vrt` file using `get_dem_tile_paths`.
+- Utilizes `get_dem_tile_paths` in main `stitch_dem` for easier testing.
+- Caches dem tile extents loaded from compressed geojson.
+
+## Removed
+- `driver` keyword in `stitch_dem`.
+
 ## [2.4.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Although the thrust of using this package is for staging DEMs for InSAR (particu
 
 ## About the raster metadata
 
-The creation metadata unrelated to georeferencing (e.g. the `compress` key or various other options [here](https://rasterio.readthedocs.io/en/latest/topics/image_options.html#creation-options)) returned in the dictionary `profile` from the `stitch_dem` API is copied directly from the source tiles being used. Although a `driver` keyword can be specified through this API directly, we recommend using the default `GTiff` option. We caution that the creation metadata copied from the source DEM tile set may not be valid with the other possible drivers and has not been tested in this library. Furthermore, different distributions of `rasterio` support different of subsets drivers; however, `GTiff` is the default driver in `rasterio` and supported across all distributions. Such metadata creation options are beyond the scope of this library.
+The creation metadata unrelated to georeferencing (e.g. the `compress` key or various other options [here](https://rasterio.readthedocs.io/en/latest/topics/image_options.html#creation-options)) returned in the dictionary `profile` from the `stitch_dem` API is copied directly from the source tiles being used if they are GeoTiff formatted (such as `glo_30`) else the creation metadata are copied from the GeoTiff Default Profile in `rasterio` (see [here](https://github.com/rasterio/rasterio/blob/0feec999775f3108abf9f50beea044bb3d4756d2/rasterio/profiles.py) excluding `nodata` and `dtype`). Such metadata creation options are beyond the scope of this library.
 
 ## Credentials
 
@@ -79,6 +79,7 @@ We have notebooks to demonstrate common usage:
 
 + [Basic Demo](notebooks/Basic_Demo.ipynb)
 + [Comparing DEMs](notebooks/Comparing_DEMs.ipynb)
++ [Generating a VRT from source DEM tiles](notebooks/Merging_DEM_Tiles_into_a_VRT.ipynb)
 + [Staging a DEM for ISCE2](notebooks/Staging_a_DEM_for_ISCE2.ipynb) - this notebook requires the installation of a few extra libraries including ISCE2 via `conda-forge`
 
 We also demonstrate how the tiles used to organize the urls for the DEMs were generated for this tool were generated in this [notebook](notebooks/organize_tile_data/).

--- a/dem_stitcher/__init__.py
+++ b/dem_stitcher/__init__.py
@@ -4,7 +4,7 @@ import warnings
 from importlib_metadata import PackageNotFoundError, version
 
 from .datasets import get_global_dem_tile_extents, get_overlapping_dem_tiles
-from .stitcher import stitch_dem
+from .stitcher import get_dem_tile_paths, stitch_dem
 
 try:
     __version__ = version(__name__)
@@ -16,6 +16,7 @@ except PackageNotFoundError:
 
 
 __all__ = [
+    'get_dem_tile_paths',
     'get_global_dem_tile_extents',
     'get_overlapping_dem_tiles',
     'stitch_dem',

--- a/dem_stitcher/datasets.py
+++ b/dem_stitcher/datasets.py
@@ -1,4 +1,6 @@
+from functools import lru_cache
 from pathlib import Path
+from warnings import warn
 
 import geopandas as gpd
 import pandas as pd
@@ -20,6 +22,8 @@ def get_available_datasets():
     return DATASETS
 
 
+# TODO: maxsize=None is not needed for 3.8+
+@lru_cache(maxsize=None)
 def get_global_dem_tile_extents(dataset: str) -> gpd.GeoDataFrame:
     """Obtains globally avaialable tiles from DEM names supported.
 
@@ -75,6 +79,10 @@ def get_overlapping_dem_tiles(bounds: list, dem_name: str) -> gpd.GeoDataFrame:
 
     crossing = get_dateline_crossing(bounds)
     if crossing:
+        warn('Getting tiles across dateline on the opposite hemisphere; '
+             f'The source tiles will be {- 2 * crossing} deg along the'
+             'longitudinal axis from the extent requested',
+             category=UserWarning)
         df_tiles_all_translated = df_tiles_all.copy()
         x_translation = 2 * crossing
         df_tiles_all_translated.geometry = df_tiles_all.geometry.translate(xoff=x_translation)

--- a/dem_stitcher/dem_readers.py
+++ b/dem_stitcher/dem_readers.py
@@ -9,8 +9,10 @@ from rasterio.io import MemoryFile
 
 
 def read_dem(dem_path: str) -> rasterio.DatasetReader:
-    ds = rasterio.open(dem_path)
-    return ds
+    with rasterio.open(dem_path) as ds:
+        dem_arr = ds.read(1)
+        dem_profile = ds.profile
+    return dem_arr, dem_profile
 
 
 def read_dem_bytes(dem_path: str, suffix: str = '.img') -> bytes:

--- a/notebooks/Merging_DEM_Tiles_into_a_VRT.ipynb
+++ b/notebooks/Merging_DEM_Tiles_into_a_VRT.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a43a588c",
+   "metadata": {},
+   "source": [
+    "This shows how to merge (source) DEM tiles using the subroutine `get_dem_tile_paths` and then into a VRT using [`gdal.BuildVRT`](https://gis.stackexchange.com/a/314580). This can be completed localizing the data, or if urls point to geotiff files as is the case with `glo_30`, using the urls directly. Because `stitch_dem` places all rasters in memory, `stitch_dem` is not applicable to larger areas e.g. across the continental United States. `get_dem_tile_paths`  allows for handling the tiles directly without transformations.\n",
+    "\n",
+    "**Note**: `get_dem_tile_paths` demonstration below does not perform any transformations e.g. conversion from geoid to ellipsoidal height. Such tile transformations are in the domain of `stitch_dem`, but can be adapted to the tiles directly using various functions in this library.\n",
+    "\n",
+    "**Warning**: `get_dem_tile_paths` does not perform any dateline wrapping/unwrapping of the rasters. However, the function does wrap the extent and returns all tile paths colocated in an input extent. Thus, if an extent passes across the dateline, then it will get tiles at opposite hemispheres. In order to format into a contiguous raster, the tiles will require translation of their geotransform. This wrapping/unwrapping of the rasters is done automatically in `stitch_dem`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "000d2379",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-23T22:43:17.266553Z",
+     "start_time": "2023-03-23T22:43:17.240949Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5733d6f1",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-23T22:43:18.530721Z",
+     "start_time": "2023-03-23T22:43:17.736621Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dem_stitcher.stitcher import get_dem_tile_paths, get_overlapping_dem_tiles\n",
+    "from osgeo import gdal\n",
+    "import rasterio"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "269a058f",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-23T22:43:19.121189Z",
+     "start_time": "2023-03-23T22:43:19.088647Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dem_name = 'glo_30'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40c3acbb",
+   "metadata": {},
+   "source": [
+    "There is an option to localize the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ba77a6e4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-23T22:43:29.127436Z",
+     "start_time": "2023-03-23T22:43:28.185051Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['https://copernicus-dem-30m.s3.amazonaws.com/Copernicus_DSM_COG_10_N34_00_W121_00_DEM/Copernicus_DSM_COG_10_N34_00_W121_00_DEM.tif',\n",
+       " 'https://copernicus-dem-30m.s3.amazonaws.com/Copernicus_DSM_COG_10_N35_00_W121_00_DEM/Copernicus_DSM_COG_10_N35_00_W121_00_DEM.tif',\n",
+       " 'https://copernicus-dem-30m.s3.amazonaws.com/Copernicus_DSM_COG_10_N35_00_W122_00_DEM/Copernicus_DSM_COG_10_N35_00_W122_00_DEM.tif',\n",
+       " 'https://copernicus-dem-30m.s3.amazonaws.com/Copernicus_DSM_COG_10_N36_00_W121_00_DEM/Copernicus_DSM_COG_10_N36_00_W121_00_DEM.tif',\n",
+       " 'https://copernicus-dem-30m.s3.amazonaws.com/Copernicus_DSM_COG_10_N36_00_W122_00_DEM/Copernicus_DSM_COG_10_N36_00_W122_00_DEM.tif']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dem_tile_paths = get_dem_tile_paths(bounds = [-121.5, 34.95, -120.2, 36.25], \n",
+    "                                    dem_name=dem_name, \n",
+    "                                    localize_tiles_to_gtiff=(False if dem_name == 'glo_30' else True), \n",
+    "                                    tile_dir=f'{dem_name}_tiles')\n",
+    "dem_tile_paths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f4848969",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-23T22:43:29.512774Z",
+     "start_time": "2023-03-23T22:43:29.480529Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "vrt_path = f'{dem_name}.vrt'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3d642224",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-23T22:44:39.119320Z",
+     "start_time": "2023-03-23T22:43:29.984396Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ds = gdal.BuildVRT(vrt_path, dem_tile_paths)\n",
+    "ds = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc3072c4",
+   "metadata": {},
+   "source": [
+    "Note the bounds contain the original requested area (as the tiles cover the entire area)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "03cdc596",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-03-23T22:44:39.156299Z",
+     "start_time": "2023-03-23T22:44:39.121310Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "BoundingBox(left=-122.00013888888888, bottom=34.00013888888889, right=-120.00013888888888, top=37.00013888888889)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with rasterio.open(vrt_path) as ds:\n",
+    "    bounds = ds.bounds\n",
+    "bounds"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dem-stitcher",
+   "language": "python",
+   "name": "dem-stitcher"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Staging_a_DEM_for_ISCE2.ipynb
+++ b/notebooks/Staging_a_DEM_for_ISCE2.ipynb
@@ -166,7 +166,7 @@
     "                                        dem_name,\n",
     "                                        dst_ellipsoidal_height=True,\n",
     "                                        dst_area_or_point='Point',\n",
-    "                                        max_workers=5,\n",
+    "                                        n_threads_downloading=5,\n",
     "                                        # ensures square resolution\n",
     "                                        dst_resolution=dem_res\n",
     "                                        )\n",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,12 @@ from rasterio.crs import CRS
 
 
 @pytest.fixture(scope='session')
+def test_dir():
+    test_dir = Path(__file__).resolve().parent
+    return test_dir
+
+
+@pytest.fixture(scope='session')
 def test_data_dir():
     data_dir = Path(__file__).resolve().parent / 'data'
     return data_dir

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from dem_stitcher.datasets import get_overlapping_dem_tiles
@@ -16,3 +18,14 @@ dem_names = ['glo_90_missing', 'glo_30']
 def test_empty_tiles(extent, dem_name):
     df_tiles = get_overlapping_dem_tiles(extent, dem_name)
     assert df_tiles.empty
+
+
+def test_dateline_warning():
+    extent_no_dateline = [-121.5, 34.95, -120.2, 36.25]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        get_overlapping_dem_tiles(extent_no_dateline, 'glo_30')
+
+    extent_with_dateline = [-181, 51.25, -179, 51.75]
+    with pytest.warns(UserWarning):
+        get_overlapping_dem_tiles(extent_with_dateline, 'glo_30')

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -4,7 +4,8 @@ import pytest
 
 notebooks = ['Basic_Demo.ipynb',
              'Comparing_DEMs.ipynb',
-             'Filling_in_missing_glo-30_tiles_with_glo-90_tiles.ipynb'
+             'Filling_in_missing_glo-30_tiles_with_glo-90_tiles.ipynb',
+             'Merging_DEM_Tiles_into_a_VRT.ipynb'
              ]
 
 


### PR DESCRIPTION
- Breaks out function to obtain urls or local paths to original dem paths: `get_dem_tile_paths`
- Removes `driver` keyword in `stitch_dem`.