### PR TITLE
v2.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.4]
+* Fix urls found in pyproject.toml so they correctly link on PyPI
+
 ## [2.5.3]
 * Updated license in pyproject.toml that was causing pypi to reject upload
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ develop = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/OPERA-Cal-Val/tile-stitcher"
-"Bug Tracker" = "https://github.com/OPERA-Cal-Val/tile-stitcher/issues"
+Homepage = "https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher"
+"Bug Tracker" = "https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/issues"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
Fixes urls in pyproject.toml so they correctly link to this github repository