### PR TITLE
v2.5.5

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.8.3
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       SDIST_VERSION: ${{ steps.build.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
 

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.8.3
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.11.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.8.3
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.11.0
     with:
       release_prefix: dem-stitcher
       develop_branch: dev

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.8.3
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.11.0
     with:
       local_package_names: dem_stitcher
 
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.8.3
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.11.0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,3 +10,6 @@ jobs:
 
   call-secrets-analysis-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.11.0
+  
+  call-ruff-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.11.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.8.3
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.0
     with:
       user: access-cloud-insar-team
       email: access-cloud-insar-team@jpl.nasa.gov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: extractions/netrc@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test and Tag
+name: Pytest 
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.5]
+* Multithreading for windowed reading during merge operation
+* Add 3.12 support
+* Introduce ruffformatting - i.e. add ruff workflow to actions for static analysis and reformat python files.
+* Provide separate progress bar for opening dataset, reading tile metadata, and reading tile array.
+* Supresses: `RuntimeWarning: invalid value encountered in intersection` from `shapely`
+
 ## [2.5.4]
 * Fix urls found in pyproject.toml so they correctly link on PyPI
 

--- a/dem_stitcher/__init__.py
+++ b/dem_stitcher/__init__.py
@@ -10,15 +10,18 @@ try:
     __version__ = version(__name__)
 except PackageNotFoundError:
     __version__ = None
-    warnings.warn('package is not installed!\n'
-                  'Install in editable/develop mode via (from the top of this repo):\n'
-                  '   python -m pip install -e .\n', RuntimeWarning)
+    warnings.warn(
+        "package is not installed!\n"
+        "Install in editable/develop mode via (from the top of this repo):\n"
+        "   python -m pip install -e .\n",
+        RuntimeWarning,
+    )
 
 
 __all__ = [
-    'get_dem_tile_paths',
-    'get_global_dem_tile_extents',
-    'get_overlapping_dem_tiles',
-    'stitch_dem',
-    '__version__',
+    "get_dem_tile_paths",
+    "get_global_dem_tile_extents",
+    "get_overlapping_dem_tiles",
+    "stitch_dem",
+    "__version__",
 ]

--- a/dem_stitcher/datasets.py
+++ b/dem_stitcher/datasets.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import lru_cache
 from pathlib import Path
 from warnings import warn
@@ -11,11 +12,11 @@ from .dateline import check_4326_bounds, get_dateline_crossing
 from .exceptions import DEMNotSupported
 from .geojson_io import read_geojson_gzip
 
-DATA_PATH = Path(__file__).parents[0].absolute()/'data'
+DATA_PATH = Path(__file__).parents[0].absolute() / "data"
 
 # Get Datasets
-_DATASET_PATHS = list(DATA_PATH.glob('*.geojson.zip'))
-DATASETS = list(map(lambda x: x.name.split('.')[0], _DATASET_PATHS))
+_DATASET_PATHS = list(DATA_PATH.glob("*.geojson.zip"))
+DATASETS = list(map(lambda x: x.name.split(".")[0], _DATASET_PATHS))
 
 
 def get_available_datasets():
@@ -44,8 +45,8 @@ def get_global_dem_tile_extents(dataset: str) -> gpd.GeoDataFrame:
     """
     if dataset not in DATASETS:
         raise DEMNotSupported(f'{dataset} must be in {", ".join(DATASETS)}')
-    df = read_geojson_gzip(DATA_PATH / f'{dataset}.geojson.zip')
-    df['dem_name'] = dataset
+    df = read_geojson_gzip(DATA_PATH / f"{dataset}.geojson.zip")
+    df["dem_name"] = dataset
     df.crs = CRS.from_epsg(4326)
     return df
 
@@ -79,10 +80,12 @@ def get_overlapping_dem_tiles(bounds: list, dem_name: str) -> gpd.GeoDataFrame:
 
     crossing = get_dateline_crossing(bounds)
     if crossing:
-        warn('Getting tiles across dateline on the opposite hemisphere; '
-             f'The source tiles will be {- 2 * crossing} deg along the'
-             'longitudinal axis from the extent requested',
-             category=UserWarning)
+        warn(
+            "Getting tiles across dateline on the opposite hemisphere; "
+            f"The source tiles will be {- 2 * crossing} deg along the"
+            "longitudinal axis from the extent requested",
+            category=UserWarning,
+        )
         df_tiles_all_translated = df_tiles_all.copy()
         x_translation = 2 * crossing
         df_tiles_all_translated.geometry = df_tiles_all.geometry.translate(xoff=x_translation)
@@ -95,17 +98,20 @@ def get_overlapping_dem_tiles(bounds: list, dem_name: str) -> gpd.GeoDataFrame:
     # If empty, then additional intersection removes column names so addition this conditional flow
     # so subsequent sorting does not fail
     if not df_tiles.empty:
-        df_tiles_intersection = df_tiles.geometry.intersection(box_geo)
-        geo_type_index = df_tiles_intersection.geometry.map(lambda geo: geo.geom_type == 'Polygon')
+        # Degenerate geometries raise warning in shapely - intersection is black box to us
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            df_tiles_intersection = df_tiles.geometry.intersection(box_geo)
+            geo_type_index = df_tiles_intersection.geometry.map(lambda geo: geo.geom_type == "Polygon")
         df_tiles = df_tiles[geo_type_index].copy()
 
     # Merging is order dependent - ensures consistency
-    df_tiles = df_tiles.sort_values(by='tile_id')
+    df_tiles = df_tiles.sort_values(by="tile_id")
     df_tiles = df_tiles.reset_index(drop=True)
     return df_tiles
 
 
 def intersects_missing_glo_30_tiles(extent: list) -> bool:
     extent_geo = box(*extent)
-    df_missing = get_overlapping_dem_tiles(extent, 'glo_90_missing')
+    df_missing = get_overlapping_dem_tiles(extent, "glo_90_missing")
     return df_missing.intersects(extent_geo).sum() > 0

--- a/dem_stitcher/dateline.py
+++ b/dem_stitcher/dateline.py
@@ -1,3 +1,5 @@
+import warnings
+
 from shapely.affinity import translate
 from shapely.geometry import box
 
@@ -5,21 +7,22 @@ from .exceptions import DoubleDatelineCrossing, Incorrect4326Bounds
 
 
 def check_4326_bounds(bounds: list) -> bool:
-
     xmin, ymin, xmax, ymax = bounds
 
     if (xmin > xmax) or (ymin > ymax):
-        raise Incorrect4326Bounds('Ensure xmin <= xmax and ymin <= ymax')
+        raise Incorrect4326Bounds("Ensure xmin <= xmax and ymin <= ymax")
 
     standard_4326_box = box(-180, -90, 180, 90)
     bounds_box = box(*bounds)
 
     if not (standard_4326_box.intersects(bounds_box)):
-        raise Incorrect4326Bounds('Make sure bounds have intersection over standard 4326 CRS i.e. '
-                                  'between longitude -180 and 180 and latitude -90 and 90.')
+        raise Incorrect4326Bounds(
+            "Make sure bounds have intersection over standard 4326 CRS i.e. "
+            "between longitude -180 and 180 and latitude -90 and 90."
+        )
 
     if (ymin < -90) or (ymax > 90):
-        raise Incorrect4326Bounds('Boxes beyond the North/South Pole at +/- 90 Latitude not supported')
+        raise Incorrect4326Bounds("Boxes beyond the North/South Pole at +/- 90 Latitude not supported")
 
     return True
 
@@ -62,7 +65,7 @@ def get_dateline_crossing(bounds: list) -> int:
         return 180
 
     elif (xmin <= -180) and (xmax >= 180):
-        raise DoubleDatelineCrossing('Shrink your bounding area')
+        raise DoubleDatelineCrossing("Shrink your bounding area")
 
 
 def split_extent_across_dateline(extent: list) -> tuple[list]:
@@ -90,13 +93,15 @@ def split_extent_across_dateline(extent: list) -> tuple[list]:
         right_hemisphere = box(0, -90, 180, 90)
 
         extent_box = box(*extent)
-        translation_x = - crossing * 2
+        translation_x = -crossing * 2
 
         extent_box_t = translate(extent_box, translation_x, 0)
         multipolygon = extent_box.union(extent_box_t)
 
-        bounds_l = list(multipolygon.intersection(left_hemisphere).bounds)
-        bounds_r = list(multipolygon.intersection(right_hemisphere).bounds)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            bounds_l = list(multipolygon.intersection(left_hemisphere).bounds)
+            bounds_r = list(multipolygon.intersection(right_hemisphere).bounds)
         return (bounds_l, bounds_r)
 
     else:

--- a/dem_stitcher/dem_readers.py
+++ b/dem_stitcher/dem_readers.py
@@ -15,9 +15,9 @@ def read_dem(dem_path: str) -> rasterio.DatasetReader:
     return dem_arr, dem_profile
 
 
-def read_dem_bytes(dem_path: str, suffix: str = '.img') -> bytes:
+def read_dem_bytes(dem_path: str, suffix: str = ".img") -> bytes:
     # online
-    if (dem_path[:7] == 'http://') or (dem_path[:8] == 'https://'):
+    if (dem_path[:7] == "http://") or (dem_path[:8] == "https://"):
         resp = requests.get(dem_path)
         data = io.BytesIO(resp.content)
     # local file
@@ -35,17 +35,17 @@ def read_dem_bytes(dem_path: str, suffix: str = '.img') -> bytes:
     return img_bytes
 
 
-def read_srtm(dem_path: str, version='srtm') -> Tuple[np.ndarray, dict]:
-    img_bytes = read_dem_bytes(dem_path, suffix='.hgt')
+def read_srtm(dem_path: str, version="srtm") -> Tuple[np.ndarray, dict]:
+    img_bytes = read_dem_bytes(dem_path, suffix=".hgt")
     # The gdal driver hgt depends on filename convention
-    filename = dem_path.split('/')[-1]
-    if version == 'srtm':
-        filename = filename.replace('.zip', '')
-    elif version == 'nasadem':
-        filename = filename.replace('.zip', '.hgt')
-        filename = filename.replace('NASADEM_HGT_', '')
+    filename = dem_path.split("/")[-1]
+    if version == "srtm":
+        filename = filename.replace(".zip", "")
+    elif version == "nasadem":
+        filename = filename.replace(".zip", ".hgt")
+        filename = filename.replace("NASADEM_HGT_", "")
     else:
-        raise ValueError('version must be either nasadem or srtm')
+        raise ValueError("version must be either nasadem or srtm")
 
     with MemoryFile(img_bytes, filename=filename) as memfile:
         with memfile.open() as dataset:
@@ -56,4 +56,4 @@ def read_srtm(dem_path: str, version='srtm') -> Tuple[np.ndarray, dict]:
 
 
 def read_nasadem(dem_path: str) -> Tuple[np.ndarray, dict]:
-    return read_srtm(dem_path, version='nasadem')
+    return read_srtm(dem_path, version="nasadem")

--- a/dem_stitcher/geoid.py
+++ b/dem_stitcher/geoid.py
@@ -11,10 +11,12 @@ from .merge import merge_arrays_with_geometadata
 from .rio_tools import reproject_arr_to_match_profile, translate_profile
 from .rio_window import read_raster_from_window
 
-AGISOFT_URL = 'http://download.agisoft.com/geoids'
-GEOID_PATHS_AGI = {'geoid_18': f'{DATA_PATH}/geoid_18.tif',
-                   'egm_08': f'{AGISOFT_URL}/egm2008-1.tif',
-                   'egm_96': f'{AGISOFT_URL}/egm96-15.tif'}
+AGISOFT_URL = "http://download.agisoft.com/geoids"
+GEOID_PATHS_AGI = {
+    "geoid_18": f"{DATA_PATH}/geoid_18.tif",
+    "egm_08": f"{AGISOFT_URL}/egm2008-1.tif",
+    "egm_96": f"{AGISOFT_URL}/egm96-15.tif",
+}
 
 
 def get_geoid_dict() -> dict:
@@ -22,10 +24,7 @@ def get_geoid_dict() -> dict:
     return geoid_dict.copy()
 
 
-def read_geoid(geoid_name: str,
-               extent: list = None,
-               res_buffer: int = 1) -> tuple:
-
+def read_geoid(geoid_name: str, extent: list = None, res_buffer: int = 1) -> tuple:
     geoid_dict = get_geoid_dict()
     geoid_path = geoid_dict[geoid_name]
 
@@ -38,73 +37,60 @@ def read_geoid(geoid_name: str,
         crossing = get_dateline_crossing(extent)
 
         if crossing == 0:
-            geoid_arr, geoid_profile = read_raster_from_window(geoid_path,
-                                                               extent,
-                                                               extent_crs,
-                                                               res_buffer=res_buffer)
+            geoid_arr, geoid_profile = read_raster_from_window(geoid_path, extent, extent_crs, res_buffer=res_buffer)
         else:
             extent_l, extent_r = split_extent_across_dateline(extent)
-            geoid_arr_l, geoid_profile_l = read_raster_from_window(geoid_path,
-                                                                   extent_l,
-                                                                   extent_crs,
-                                                                   res_buffer=res_buffer)
-            geoid_arr_r, geoid_profile_r = read_raster_from_window(geoid_path,
-                                                                   extent_r,
-                                                                   extent_crs,
-                                                                   res_buffer=res_buffer)
-            res_x = geoid_profile_l['transform'].a
+            geoid_arr_l, geoid_profile_l = read_raster_from_window(
+                geoid_path, extent_l, extent_crs, res_buffer=res_buffer
+            )
+            geoid_arr_r, geoid_profile_r = read_raster_from_window(
+                geoid_path, extent_r, extent_crs, res_buffer=res_buffer
+            )
+            res_x = geoid_profile_l["transform"].a
             if crossing == 180:
                 geoid_profile_l = translate_profile(geoid_profile_l, 360 / res_x, 0)
             else:
                 geoid_profile_r = translate_profile(geoid_profile_r, -360 / res_x, 0)
-            geoid_arr, geoid_profile = merge_arrays_with_geometadata([geoid_arr_l, geoid_arr_r],
-                                                                     [geoid_profile_l, geoid_profile_r])
+            geoid_arr, geoid_profile = merge_arrays_with_geometadata(
+                [geoid_arr_l, geoid_arr_r], [geoid_profile_l, geoid_profile_r]
+            )
     # Transform nodata to nan
-    geoid_arr = geoid_arr.astype('float32')
-    geoid_arr[geoid_profile['nodata'] == geoid_arr] = np.nan
-    geoid_profile['nodata'] = np.nan
+    geoid_arr = geoid_arr.astype("float32")
+    geoid_arr[geoid_profile["nodata"] == geoid_arr] = np.nan
+    geoid_profile["nodata"] = np.nan
 
     return geoid_arr, geoid_profile
 
 
-def remove_geoid(dem_arr: np.ndarray,
-                 dem_profile: dict,
-                 geoid_name: str,
-                 dem_area_or_point: str = 'Area',
-                 res_buffer: int = 2) -> np.ndarray:
+def remove_geoid(
+    dem_arr: np.ndarray, dem_profile: dict, geoid_name: str, dem_area_or_point: str = "Area", res_buffer: int = 2
+) -> np.ndarray:
+    assert dem_area_or_point in ["Point", "Area"]
 
-    assert dem_area_or_point in ['Point', 'Area']
+    extent = array_bounds(dem_profile["height"], dem_profile["width"], dem_profile["transform"])
 
-    extent = array_bounds(dem_profile['height'],
-                          dem_profile['width'],
-                          dem_profile['transform'])
+    geoid_arr, geoid_profile = read_geoid(geoid_name, extent=list(extent), res_buffer=res_buffer)
 
-    geoid_arr, geoid_profile = read_geoid(geoid_name,
-                                          extent=list(extent),
-                                          res_buffer=res_buffer)
-
-    t_dem = dem_profile['transform']
-    t_geoid = geoid_profile['transform']
+    t_dem = dem_profile["transform"]
+    t_geoid = geoid_profile["transform"]
     res_dem = max(t_dem.a, abs(t_dem.e))
     res_geoid = max(t_geoid.a, abs(t_geoid.e))
 
     if res_geoid * res_buffer <= res_dem:
         buffer_recommendation = int(np.ceil(res_dem / res_geoid))
-        warning = ('The dem resolution is larger than the geoid resolution and its buffer; '
-                   'Edges resampled with bilinear interpolation will be inconsistent so select larger buffer.'
-                   f'Select a `res_buffer = {buffer_recommendation}`')
+        warning = (
+            "The dem resolution is larger than the geoid resolution and its buffer; "
+            "Edges resampled with bilinear interpolation will be inconsistent so select larger buffer."
+            f"Select a `res_buffer = {buffer_recommendation}`"
+        )
         warnings.warn(warning, category=UserWarning)
 
     # Translate geoid if necessary as all geoids have Area tag
-    if dem_area_or_point == 'Point':
-        shift = -.5
-        geoid_profile = translate_profile(geoid_profile,
-                                          shift, shift)
+    if dem_area_or_point == "Point":
+        shift = -0.5
+        geoid_profile = translate_profile(geoid_profile, shift, shift)
 
-    geoid_offset, _ = reproject_arr_to_match_profile(geoid_arr,
-                                                     geoid_profile,
-                                                     dem_profile,
-                                                     resampling='bilinear')
+    geoid_offset, _ = reproject_arr_to_match_profile(geoid_arr, geoid_profile, dem_profile, resampling="bilinear")
 
     dem_arr_offset = dem_arr + geoid_offset
     return dem_arr_offset

--- a/dem_stitcher/geojson_io.py
+++ b/dem_stitcher/geojson_io.py
@@ -9,31 +9,26 @@ from rasterio.crs import CRS
 
 
 def read_geojson_gzip(input_zip_path: Union[str, Path]) -> gpd.GeoDataFrame:
-    with gzip.GzipFile(input_zip_path, 'r') as file_in:
-        data_gjson = json.loads(file_in.read().decode('utf-8'))
-    return gpd.GeoDataFrame.from_features(data_gjson['features'],
-                                          crs=CRS.from_epsg(4326))
+    with gzip.GzipFile(input_zip_path, "r") as file_in:
+        data_gjson = json.loads(file_in.read().decode("utf-8"))
+    return gpd.GeoDataFrame.from_features(data_gjson["features"], crs=CRS.from_epsg(4326))
 
 
 def to_geojson_obj(geodataframe: gpd.geodataframe.GeoDataFrame) -> dict:
-    features = geodataframe.to_dict('records')
+    features = geodataframe.to_dict("records")
 
     def mapping_geojson(entry):
-        geometry = entry.pop('geometry')
-        new_entry = {"type": "Feature",
-                     "properties": entry,
-                     "geometry": shapely.geometry.mapping(geometry)}
+        geometry = entry.pop("geometry")
+        new_entry = {"type": "Feature", "properties": entry, "geometry": shapely.geometry.mapping(geometry)}
         return new_entry
+
     features = list(map(mapping_geojson, features))
-    geojson = {"type": "FeatureCollection",
-               "features": features
-               }
+    geojson = {"type": "FeatureCollection", "features": features}
     return geojson
 
 
-def to_geojson_gzip(geodataframe: gpd.geodataframe.GeoDataFrame,
-                    dest_path: str) -> Path:
+def to_geojson_gzip(geodataframe: gpd.geodataframe.GeoDataFrame, dest_path: str) -> Path:
     geojson_ob = to_geojson_obj(geodataframe)
-    with gzip.GzipFile(dest_path, 'w') as file_out:
-        file_out.write(json.dumps(geojson_ob).encode('utf-8'))
+    with gzip.GzipFile(dest_path, "w") as file_out:
+        file_out.write(json.dumps(geojson_ob).encode("utf-8"))
     return dest_path

--- a/dem_stitcher/rio_window.py
+++ b/dem_stitcher/rio_window.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from warnings import warn
 
 import numpy as np
@@ -12,33 +13,26 @@ from shapely.geometry import box
 
 
 def get_array_bounds(profile: dict) -> list[float]:
-    return array_bounds(profile['height'],
-                        profile['width'],
-                        profile['transform'])
+    return array_bounds(profile["height"], profile["width"], profile["transform"])
 
 
-def transform_bounds(src_bounds: list,
-                     src_crs: CRS,
-                     dest_crs: CRS) -> list[float]:
+def transform_bounds(src_bounds: list, src_crs: CRS, dest_crs: CRS) -> list[float]:
     """
     Source: https://gis.stackexchange.com/a/392407
     """
 
     proj = Transformer.from_crs(src_crs, dest_crs, always_xy=True)
 
-    bl = proj.transform(src_bounds[0],
-                        src_bounds[1])
-    tr = proj.transform(src_bounds[2],
-                        src_bounds[3])
+    bl = proj.transform(src_bounds[0], src_bounds[1])
+    tr = proj.transform(src_bounds[2], src_bounds[3])
     dest_bounds = list(bl) + list(tr)
 
     return dest_bounds
 
 
-def get_indices_from_extent(transform: Affine,
-                            extent: list[float],
-                            shape: tuple = None,
-                            res_buffer: int = 0) -> tuple[tuple]:
+def get_indices_from_extent(
+    transform: Affine, extent: list[float], shape: tuple = None, res_buffer: int = 0
+) -> tuple[tuple]:
     """Obtain Upper left corner and bottom right corner from extents based on
     geo-transform that specifies resolution and upper left corner of a coordinate
     system
@@ -69,78 +63,69 @@ def get_indices_from_extent(transform: Affine,
     row_ul, col_ll = rowcol(transform, xmin, ymax, op=math.floor)
     row_br, col_br = rowcol(transform, xmax, ymin, op=math.ceil)
 
-    corner_ul = (max(row_ul - res_buffer, 0),
-                 max(col_ll - res_buffer, 0))
+    corner_ul = (max(row_ul - res_buffer, 0), max(col_ll - res_buffer, 0))
 
     height, width = (np.inf, np.inf)
     if shape is not None:
         assert len(shape) in [2, 3]
         height, width = shape[-2:]
 
-    corner_br = (min(row_br + res_buffer, height),
-                 min(col_br + res_buffer, width))
+    corner_br = (min(row_br + res_buffer, height), min(col_br + res_buffer, width))
 
     return corner_ul, corner_br
 
 
-def get_window_from_extent(src_profile: dict,
-                           window_extent,
-                           window_crs: CRS = CRS.from_epsg(4326),
-                           res_buffer: int = 0) -> Window:
-
-    src_shape = src_profile['height'], src_profile['width']
+def get_window_from_extent(
+    src_profile: dict, window_extent, window_crs: CRS = CRS.from_epsg(4326), res_buffer: int = 0
+) -> Window:
+    src_shape = src_profile["height"], src_profile["width"]
     src_bounds = get_array_bounds(src_profile)
-    window_extent_r = transform_bounds(window_extent,
-                                       window_crs,
-                                       src_profile['crs'])
+    window_extent_r = transform_bounds(window_extent, window_crs, src_profile["crs"])
 
     src_bbox_geo = box(*src_bounds)
     win_bbox_geo = box(*window_extent_r)
 
-    intersection_geo = src_bbox_geo.intersection(win_bbox_geo)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        intersection_geo = src_bbox_geo.intersection(win_bbox_geo)
 
-    if intersection_geo.geom_type != 'Polygon':
-        raise RuntimeError('The intersection geometry is degenerate (i.e. a '
-                           f'Point or LineString: {intersection_geo.geom_type}')
+    if intersection_geo.geom_type != "Polygon":
+        raise RuntimeError(
+            "The intersection geometry is degenerate (i.e. a " f"Point or LineString: {intersection_geo.geom_type}"
+        )
     if not intersection_geo.is_empty:
         window_extent_r = intersection_geo.bounds
         if not src_bbox_geo.contains(win_bbox_geo):
-            warn(f'Requesting extent beyond raster bounds of {list(src_bounds)}'
-                 f'. Shrinking bounds in raster crs to {window_extent_r}.',
-                 category=RuntimeWarning)
+            warn(
+                f"Requesting extent beyond raster bounds of {list(src_bounds)}"
+                f". Shrinking bounds in raster crs to {window_extent_r}.",
+                category=RuntimeWarning,
+            )
     else:
-        raise RuntimeError('The extent you specified does not overlap'
-                           ' the specified raster as a Polygon.')
+        raise RuntimeError("The extent you specified does not overlap" " the specified raster as a Polygon.")
 
-    corner_ul, corner_br = get_indices_from_extent(src_profile['transform'],
-                                                   window_extent_r,
-                                                   shape=src_shape,
-                                                   res_buffer=res_buffer
-                                                   )
+    corner_ul, corner_br = get_indices_from_extent(
+        src_profile["transform"], window_extent_r, shape=src_shape, res_buffer=res_buffer
+    )
     row_start, col_start = corner_ul
     row_stop, col_stop = corner_br
-    window = Window.from_slices((row_start, row_stop),
-                                (col_start, col_stop))
+    window = Window.from_slices((row_start, row_stop), (col_start, col_stop))
     return window
 
 
-def format_window_profile(src_profile: dict,
-                          window_arr: np.ndarray,
-                          window_transform: Affine) -> dict:
-
+def format_window_profile(src_profile: dict, window_arr: np.ndarray, window_transform: Affine) -> dict:
     profile_window = src_profile.copy()
-    profile_window['transform'] = window_transform
+    profile_window["transform"] = window_transform
 
-    profile_window['count'] = window_arr.shape[0]
-    profile_window['height'] = window_arr.shape[1]
-    profile_window['width'] = window_arr.shape[2]
+    profile_window["count"] = window_arr.shape[0]
+    profile_window["height"] = window_arr.shape[1]
+    profile_window["width"] = window_arr.shape[2]
     return profile_window
 
 
-def read_raster_from_window(raster_path: str,
-                            window_extent: list,
-                            window_crs: CRS = CRS.from_epsg(4326),
-                            res_buffer: int = 0) -> tuple:
+def read_raster_from_window(
+    raster_path: str, window_extent: list, window_crs: CRS = CRS.from_epsg(4326), res_buffer: int = 0
+) -> tuple:
     """Obtains minimum pixels from original raster (specified by raster_path) that contain
     window extent. Does not reproject into window extent! Returns only 1st channel.
 
@@ -168,15 +153,12 @@ def read_raster_from_window(raster_path: str,
        Extent is not properly specified
     """
     if (window_extent[0] >= window_extent[2]) or (window_extent[1] >= window_extent[3]):
-        raise ValueError('Extents must be in the form of (xmin, ymin, xmax, ymax)')
+        raise ValueError("Extents must be in the form of (xmin, ymin, xmax, ymax)")
 
     with rasterio.open(raster_path) as ds:
         src_profile = ds.profile
 
-    window = get_window_from_extent(src_profile,
-                                    window_extent,
-                                    window_crs,
-                                    res_buffer=res_buffer)
+    window = get_window_from_extent(src_profile, window_extent, window_crs, res_buffer=res_buffer)
 
     with rasterio.open(raster_path) as ds:
         arr_window = ds.read(window=window)

--- a/dem_stitcher/stitcher.py
+++ b/dem_stitcher/stitcher.py
@@ -12,93 +12,95 @@ from rasterio.crs import CRS
 from rasterio.io import MemoryFile
 from tqdm import tqdm
 
-from .datasets import (get_overlapping_dem_tiles,
-                       intersects_missing_glo_30_tiles)
+from .datasets import get_overlapping_dem_tiles, intersects_missing_glo_30_tiles
 from .dateline import get_dateline_crossing
 from .dem_readers import read_dem, read_nasadem, read_srtm
 from .exceptions import NoDEMCoverage
 from .geoid import remove_geoid
 from .merge import merge_arrays_with_geometadata, merge_tile_datasets_within_extent
-from .rio_tools import (reproject_arr_to_match_profile,
-                        reproject_arr_to_new_crs, translate_dataset,
-                        translate_profile, update_profile_resolution)
+from .rio_tools import (
+    reproject_arr_to_match_profile,
+    reproject_arr_to_new_crs,
+    translate_dataset,
+    translate_profile,
+    update_profile_resolution,
+)
 
-RASTER_READERS = {'3dep': read_dem,
-                  'glo_30': read_dem,
-                  'glo_90': read_dem,
-                  'glo_90_missing': read_dem,
-                  'srtm_v3': read_srtm,
-                  'nasadem': read_nasadem}
+RASTER_READERS = {
+    "3dep": read_dem,
+    "glo_30": read_dem,
+    "glo_90": read_dem,
+    "glo_90_missing": read_dem,
+    "srtm_v3": read_srtm,
+    "nasadem": read_nasadem,
+}
 
-DEM2GEOID = {'3dep': 'geoid_18',
-             'glo_30': 'egm_08',
-             'glo_90': 'egm_08',
-             'glo_90_missing': 'egm_08',
-             'srtm_v3': 'egm_96',
-             'nasadem': 'egm_96'}
+DEM2GEOID = {
+    "3dep": "geoid_18",
+    "glo_30": "egm_08",
+    "glo_90": "egm_08",
+    "glo_90_missing": "egm_08",
+    "srtm_v3": "egm_96",
+    "nasadem": "egm_96",
+}
 
-PIXEL_CENTER_DEMS = ['srtm_v3', 'nasadem', 'glo_30', 'glo_90', 'glo_90_missing']
+PIXEL_CENTER_DEMS = ["srtm_v3", "nasadem", "glo_30", "glo_90", "glo_90_missing"]
 DEFAULT_GTIFF_PROFILE = default_gtiff_profile.copy()
-DEFAULT_GTIFF_PROFILE.pop('nodata')
-DEFAULT_GTIFF_PROFILE.pop('dtype')
+DEFAULT_GTIFF_PROFILE.pop("nodata")
+DEFAULT_GTIFF_PROFILE.pop("dtype")
 
 
-def _download_and_write_one_tile_to_gtiff(url: str,
-                                          dest_path: Path,
-                                          reader: Callable,
-                                          dem_name: str) -> dict:
+def _download_and_write_one_tile_to_gtiff(url: str, dest_path: Path, reader: Callable, dem_name: str) -> dict:
     dem_arr, dem_profile = reader(url)
-    if dem_profile['driver'] != 'GTiff':
+    if dem_profile["driver"] != "GTiff":
         dem_profile.update(**DEFAULT_GTIFF_PROFILE)
-    with rasterio.open(dest_path, 'w', **dem_profile) as ds:
+    with rasterio.open(dest_path, "w", **dem_profile) as ds:
         ds.write(dem_arr)
         if dem_name in PIXEL_CENTER_DEMS:
-            ds.update_tags(AREA_OR_POINT='Point')
+            ds.update_tags(AREA_OR_POINT="Point")
     return dem_profile
 
 
-def download_tiles_to_gtiff(urls: list,
-                            dem_name: str,
-                            dest_dir: Path,
-                            max_workers_for_download: int = 5
-                            ) -> list[Path]:
-
-    tile_ids = list(map(lambda x: x.split('/')[-1], urls))
+def download_tiles_to_gtiff(urls: list, dem_name: str, dest_dir: Path, max_workers_for_download: int = 5) -> list[Path]:
+    tile_ids = list(map(lambda x: x.split("/")[-1], urls))
 
     def extract_dest_path_from_url(tile_id):
         # glo DEMs
-        if '.tif' in tile_id:
+        if ".tif" in tile_id:
             return dest_dir / tile_id
         # USGS or NASA DEMs
-        if '.zip' in tile_id:
-            return dest_dir / tile_id.replace('.zip', '.tif')
+        if ".zip" in tile_id:
+            return dest_dir / tile_id.replace(".zip", ".tif")
         else:
-            raise ValueError('The dataset format was not considered')
+            raise ValueError("The dataset format was not considered")
 
     dest_paths = list(map(extract_dest_path_from_url, tile_ids))
     reader = RASTER_READERS[dem_name]
 
     def download_and_write_one_partial(zipped_data: list) -> dict:
-        return _download_and_write_one_tile_to_gtiff(zipped_data[0],
-                                                     zipped_data[1],
-                                                     reader,
-                                                     dem_name)
+        return _download_and_write_one_tile_to_gtiff(zipped_data[0], zipped_data[1], reader, dem_name)
 
     data_list = zip(urls, dest_paths)
     with ThreadPoolExecutor(max_workers=max_workers_for_download) as executor:
-        list(tqdm(executor.map(download_and_write_one_partial, data_list),
-                  total=len(urls),
-                  desc=f'Downloading {dem_name} tiles'))
+        list(
+            tqdm(
+                executor.map(download_and_write_one_partial, data_list),
+                total=len(urls),
+                desc=f"Downloading {dem_name} tiles",
+            )
+        )
 
     dest_paths_str = list(map(str, dest_paths))
     return dest_paths_str
 
 
-def get_dem_tile_paths(bounds: list[float],
-                       dem_name: str,
-                       localize_tiles_to_gtiff: bool = False,
-                       n_threads_downloading: int = 5,
-                       tile_dir: Union[str, Path] = None) -> list[str]:
+def get_dem_tile_paths(
+    bounds: list[float],
+    dem_name: str,
+    localize_tiles_to_gtiff: bool = False,
+    n_threads_downloading: int = 5,
+    tile_dir: Union[str, Path] = None,
+) -> list[str]:
     """Either:
 
     1. Gets (public urls) so that we can open with rasterio
@@ -128,93 +130,82 @@ def get_dem_tile_paths(bounds: list[float],
     df_tiles = get_overlapping_dem_tiles(bounds, dem_name)
     urls = df_tiles.url.tolist()
 
-    if (not localize_tiles_to_gtiff):
+    if not localize_tiles_to_gtiff:
         # Datasets that permit direct reading
-        if (dem_name in ['glo_30', 'glo_90', '3dep', 'glo_90_missing']):
+        if dem_name in ["glo_30", "glo_90", "3dep", "glo_90_missing"]:
             dem_paths = urls
         else:
-            warn(f'We need to localize the tiles as a Geotiff. Saving to {str(tile_dir)}',
-                 category=UserWarning)
+            warn(f"We need to localize the tiles as a Geotiff. Saving to {str(tile_dir)}", category=UserWarning)
 
-    if (dem_name not in ['glo_30', 'glo_90', '3dep', 'glo_90_missing']) or localize_tiles_to_gtiff:
+    if (dem_name not in ["glo_30", "glo_90", "3dep", "glo_90_missing"]) or localize_tiles_to_gtiff:
         if isinstance(tile_dir, str):
             tile_dir = Path(tile_dir)
         if tile_dir is None:
             tile_dir = Path(dem_name)
         if tile_dir.exists():
-            warn(f'The directory{tile_dir} exists; '
-                 'We are writing new files to this directory',
-                 category=UserWarning)
+            warn(f"The directory{tile_dir} exists; " "We are writing new files to this directory", category=UserWarning)
         tile_dir.mkdir(exist_ok=True, parents=True)
-        dem_paths = download_tiles_to_gtiff(urls,
-                                            dem_name,
-                                            tile_dir,
-                                            max_workers_for_download=n_threads_downloading)
+        dem_paths = download_tiles_to_gtiff(urls, dem_name, tile_dir, max_workers_for_download=n_threads_downloading)
     return dem_paths
 
 
-def shift_profile_for_pixel_loc(src_profile: dict,
-                                src_area_or_point: str,
-                                dst_area_or_point: str) -> dict:
-    assert dst_area_or_point in ['Area', 'Point']
-    assert src_area_or_point in ['Area', 'Point']
-    if (dst_area_or_point == 'Point') and (src_area_or_point == 'Area'):
-        shift = -.5
+def shift_profile_for_pixel_loc(src_profile: dict, src_area_or_point: str, dst_area_or_point: str) -> dict:
+    assert dst_area_or_point in ["Area", "Point"]
+    assert src_area_or_point in ["Area", "Point"]
+    if (dst_area_or_point == "Point") and (src_area_or_point == "Area"):
+        shift = -0.5
         profile_shifted = translate_profile(src_profile, shift, shift)
-    elif (dst_area_or_point == 'Area') and (src_area_or_point == 'Point'):
-        shift = .5
+    elif (dst_area_or_point == "Area") and (src_area_or_point == "Point"):
+        shift = 0.5
         profile_shifted = translate_profile(src_profile, shift, shift)
     else:
         profile_shifted = src_profile.copy()
     return profile_shifted
 
 
-def merge_and_transform_dem_tiles(datasets: list,
-                                  bounds: list,
-                                  dem_name: str,
-                                  dst_ellipsoidal_height: bool = True,
-                                  dst_area_or_point: str = 'Area',
-                                  dst_resolution: Union[float, tuple[float]] = None,
-                                  num_threads_reproj: int = 5,
-                                  merge_nodata_value: float = np.nan) -> tuple[np.ndarray, dict]:
-    dem_arr, dem_profile = merge_tile_datasets_within_extent(datasets,
-                                                             bounds,
-                                                             nodata=merge_nodata_value,
-                                                             dtype=np.float32)
+def merge_and_transform_dem_tiles(
+    datasets: list,
+    bounds: list,
+    dem_name: str,
+    dst_ellipsoidal_height: bool = True,
+    dst_area_or_point: str = "Area",
+    dst_resolution: Union[float, tuple[float]] = None,
+    num_threads_reproj: int = 5,
+    merge_nodata_value: float = np.nan,
+    n_threads_for_reading_tile_data: int = 5,
+) -> tuple[np.ndarray, dict]:
+    dem_arr, dem_profile = merge_tile_datasets_within_extent(
+        datasets, bounds, nodata=merge_nodata_value, dtype=np.float32, n_threads=n_threads_for_reading_tile_data
+    )
     # We could have merge_nodata_value that is zero and we want the final metadata
     # to be np.nan
-    dem_profile['nodata'] = np.nan
-    src_area_or_point = datasets[0].tags().get('AREA_OR_POINT', 'Area')
+    dem_profile["nodata"] = np.nan
+    src_area_or_point = datasets[0].tags().get("AREA_OR_POINT", "Area")
 
-    dem_profile = shift_profile_for_pixel_loc(dem_profile,
-                                              src_area_or_point,
-                                              dst_area_or_point)
+    dem_profile = shift_profile_for_pixel_loc(dem_profile, src_area_or_point, dst_area_or_point)
 
     # Reproject to 4326 for USGS DEMs over North America
     # Note 4269 is almost identical to 4326 and often no changes are made
-    if dem_profile['crs'] == CRS.from_epsg(4269):
-        dem_arr, dem_profile = reproject_arr_to_new_crs(dem_arr,
-                                                        dem_profile,
-                                                        CRS.from_epsg(4326))
+    if dem_profile["crs"] == CRS.from_epsg(4269):
+        dem_arr, dem_profile = reproject_arr_to_new_crs(dem_arr, dem_profile, CRS.from_epsg(4326))
 
-    if dem_profile['crs'] != CRS.from_epsg(4326):
-        raise ValueError('CRS must be epsg 4269 or 4326')
+    if dem_profile["crs"] != CRS.from_epsg(4326):
+        raise ValueError("CRS must be epsg 4269 or 4326")
 
     if dst_ellipsoidal_height:
         geoid_name = DEM2GEOID[dem_name]
-        dem_arr = remove_geoid(dem_arr,
-                               dem_profile,
-                               geoid_name,
-                               dem_area_or_point=dst_area_or_point,
-                               )
+        dem_arr = remove_geoid(
+            dem_arr,
+            dem_profile,
+            geoid_name,
+            dem_area_or_point=dst_area_or_point,
+        )
 
     if dst_resolution is not None:
         dem_profile_res = update_profile_resolution(dem_profile, dst_resolution)
-        dem_arr, dem_profile = reproject_arr_to_match_profile(dem_arr,
-                                                              dem_profile,
-                                                              dem_profile_res,
-                                                              num_threads=num_threads_reproj,
-                                                              resampling='bilinear')
+        dem_arr, dem_profile = reproject_arr_to_match_profile(
+            dem_arr, dem_profile, dem_profile_res, num_threads=num_threads_reproj, resampling="bilinear"
+        )
 
     # Ensure dem_arr has correct shape
     assert len(dem_arr.shape) == 3
@@ -222,26 +213,22 @@ def merge_and_transform_dem_tiles(datasets: list,
     return dem_arr, dem_profile
 
 
-def patch_glo_30_with_glo_90(arr_glo_30: np.ndarray,
-                             prof_glo_30: dict,
-                             extent: list,
-                             stitcher_kwargs: dict) -> tuple[np.ndarray, dict]:
+def patch_glo_30_with_glo_90(
+    arr_glo_30: np.ndarray, prof_glo_30: dict, extent: list, stitcher_kwargs: dict
+) -> tuple[np.ndarray, dict]:
     if not intersects_missing_glo_30_tiles(extent):
         return arr_glo_30, prof_glo_30
 
-    stitcher_kwargs['dem_name'] = 'glo_90_missing'
+    stitcher_kwargs["dem_name"] = "glo_90_missing"
     arr_glo_90, prof_glo_90 = stitch_dem(**stitcher_kwargs)
 
     # Dems internally are BIP with channel dimension exposed but stitcher api squeezes outputs
-    dem_arr, dem_prof = merge_arrays_with_geometadata([arr_glo_30.squeeze(), arr_glo_90],
-                                                      [prof_glo_30, prof_glo_90]
-                                                      )
+    dem_arr, dem_prof = merge_arrays_with_geometadata([arr_glo_30.squeeze(), arr_glo_90], [prof_glo_30, prof_glo_90])
 
     return dem_arr, dem_prof
 
 
 def _translate_one_tile_across_dateline(dataset: rasterio.DatasetReader, crossing):
-
     assert crossing in [180, -180]
     res_x = dataset.res[0]
     xmin, _, xmax, _ = dataset.bounds
@@ -262,16 +249,17 @@ def _translate_one_tile_across_dateline(dataset: rasterio.DatasetReader, crossin
     return memfile, dataset_new
 
 
-def stitch_dem(bounds: list,
-               dem_name: str,
-               dst_ellipsoidal_height: bool = True,
-               dst_area_or_point: str = 'Area',
-               dst_resolution: Union[float, tuple[float]] = None,
-               n_threads_reproj: int = 5,
-               n_threads_downloading: int = 5,
-               fill_in_glo_30: bool = True,
-               merge_nodata_value: float = np.nan
-               ) -> tuple[np.ndarray, dict]:
+def stitch_dem(
+    bounds: list,
+    dem_name: str,
+    dst_ellipsoidal_height: bool = True,
+    dst_area_or_point: str = "Area",
+    dst_resolution: Union[float, tuple[float]] = None,
+    n_threads_reproj: int = 5,
+    n_threads_downloading: int = 10,
+    fill_in_glo_30: bool = True,
+    merge_nodata_value: float = np.nan,
+) -> tuple[np.ndarray, dict]:
     """This is API for stitching DEMs. Specify bounds and various options to obtain a continuous raster.
     The output raster will be determined by availability of tiles. If no tiles are available over bounds,
     then NoDEMCoverage is raised.
@@ -293,7 +281,7 @@ def stitch_dem(bounds: list,
     n_threads_reproj : int, optional
         Threads to use for reprojection, by default 5
     n_threads_downloading : int, optional
-        Threads for downloading tiles, by default 5
+        Threads for downloading tile data, by default 10
     fill_in_glo_30 : bool, optional
         If `dem_name` is 'glo_30' then fills in missing `glo_30` tiles over Armenia and Azerbaijan with available
         `glo_90` tiles, by default True. If the extent falls inside of the missing `glo_30` tiles, then `glo_90` is
@@ -324,56 +312,60 @@ def stitch_dem(bounds: list,
         fill_in_glo_30 = fill_in_glo_30 and glo_90_missing_intersection
 
     if merge_nodata_value not in [np.nan, 0]:
-        raise ValueError('np.nan and 0 are only acceptable merge_nodata_value')
+        raise ValueError("np.nan and 0 are only acceptable merge_nodata_value")
 
     # Random unique identifier
     tmp_id = str(uuid.uuid4())
-    tile_dir = Path(f'tmp_{tmp_id}')
+    tile_dir = Path(f"tmp_{tmp_id}")
 
-    dem_paths = get_dem_tile_paths(bounds=bounds,
-                                   dem_name=dem_name,
-                                   localize_tiles_to_gtiff=False,
-                                   n_threads_downloading=n_threads_downloading,
-                                   tile_dir=tile_dir)
+    dem_paths = get_dem_tile_paths(
+        bounds=bounds,
+        dem_name=dem_name,
+        localize_tiles_to_gtiff=False,
+        n_threads_downloading=n_threads_downloading,
+        tile_dir=tile_dir,
+    )
 
-    with ThreadPoolExecutor(max_workers=n_threads_downloading) as executor:
-        datasets = list(tqdm(executor.map(rasterio.open, dem_paths),
-                             total=len(dem_paths),
-                             desc=f'Reading {dem_name} Datasets'))
+    # Opening is capped at 5 threads because more leads to errors
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        datasets = list(
+            tqdm(executor.map(rasterio.open, dem_paths), total=len(dem_paths), desc=f"Opening {dem_name} Datasets")
+        )
 
     if not datasets:
         # This is the case that an extent is entirely contained within glo_90
         # tiles that are missing from glo_30 (list of datasets is empty)
-        if (dem_name == 'glo_30') and fill_in_glo_30:
-
-            stitcher_kwargs['dem_name'] = 'glo_90_missing'
+        if (dem_name == "glo_30") and fill_in_glo_30:
+            stitcher_kwargs["dem_name"] = "glo_90_missing"
             # if dst_resolution is None, then make sure we upsample to 30 meter resolution
-            dst_resolution = stitcher_kwargs['dst_resolution']
-            stitcher_kwargs['dst_resolution'] = dst_resolution or 0.0002777777777777777775
+            dst_resolution = stitcher_kwargs["dst_resolution"]
+            stitcher_kwargs["dst_resolution"] = dst_resolution or 0.0002777777777777777775
 
             dem_arr, dem_profile = stitch_dem(**stitcher_kwargs)
             return dem_arr, dem_profile
         else:
-            raise NoDEMCoverage(f'Specified bounds are not within coverage area of {dem_name}')
+            raise NoDEMCoverage(f"Specified bounds are not within coverage area of {dem_name}")
 
     # Preserve tile metadata data not used for geo-referencing
     profile_tile = datasets[0].profile.copy()
-    [profile_tile.pop(key) for key in ['transform', 'dtype', 'height', 'width', 'nodata', 'crs']]
+    [profile_tile.pop(key) for key in ["transform", "dtype", "height", "width", "nodata", "crs"]]
 
     crossing = get_dateline_crossing(bounds)
     if crossing:
         zipped_data = list(map(lambda ds: _translate_one_tile_across_dateline(ds, crossing), datasets))
         memory_files, datasets = zip(*zipped_data)
 
-    dem_arr, dem_profile = merge_and_transform_dem_tiles(datasets,
-                                                         bounds,
-                                                         dem_name,
-                                                         dst_ellipsoidal_height=dst_ellipsoidal_height,
-                                                         dst_area_or_point=dst_area_or_point,
-                                                         dst_resolution=dst_resolution,
-                                                         num_threads_reproj=n_threads_reproj,
-                                                         merge_nodata_value=merge_nodata_value
-                                                         )
+    dem_arr, dem_profile = merge_and_transform_dem_tiles(
+        datasets,
+        bounds,
+        dem_name,
+        dst_ellipsoidal_height=dst_ellipsoidal_height,
+        dst_area_or_point=dst_area_or_point,
+        dst_resolution=dst_resolution,
+        num_threads_reproj=n_threads_reproj,
+        merge_nodata_value=merge_nodata_value,
+        n_threads_for_reading_tile_data=n_threads_downloading,
+    )
 
     # Close datasets
     list(map(lambda dataset: dataset.close(), datasets))
@@ -388,11 +380,8 @@ def stitch_dem(bounds: list,
 
     # This is the case when we have overlap of the requested extent and glo_30
     # and glo_90 tiles that are missing from glo_30.
-    if (dem_name == 'glo_30') and fill_in_glo_30:
-        dem_arr, dem_profile = patch_glo_30_with_glo_90(dem_arr,
-                                                        dem_profile,
-                                                        bounds,
-                                                        stitcher_kwargs)
+    if (dem_name == "glo_30") and fill_in_glo_30:
+        dem_arr, dem_profile = patch_glo_30_with_glo_90(dem_arr, dem_profile, bounds, stitcher_kwargs)
 
     dem_profile.update(**profile_tile)
     dem_arr = dem_arr[0, ...]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
 ]
 
 dynamic = ['version', 'readme']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,67 +7,66 @@ from rasterio import default_gtiff_profile
 from rasterio.crs import CRS
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def test_dir():
     test_dir = Path(__file__).resolve().parent
     return test_dir
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def test_data_dir():
-    data_dir = Path(__file__).resolve().parent / 'data'
+    data_dir = Path(__file__).resolve().parent / "data"
     return data_dir
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def notebooks_dir():
-    notebook_directory = Path(__file__).resolve().parents[1] / 'notebooks'
+    notebook_directory = Path(__file__).resolve().parents[1] / "notebooks"
     return notebook_directory
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def get_los_angeles_tile_dataset():
-    tiles_dir = Path(__file__).resolve().parent / 'data' / 'tiles'
+    tiles_dir = Path(__file__).resolve().parent / "data" / "tiles"
 
     def _get_tile_dataset(dem_name):
-        dem_tile_dir = tiles_dir / f'{dem_name}'
-        if dem_name == 'glo_30':
-            tile_name = 'Copernicus_DSM_COG_10_N34_00_W119_00_DEM.tif'
-        elif dem_name == 'nasadem':
-            tile_name = 'NASADEM_HGT_n34w119.tif'
+        dem_tile_dir = tiles_dir / f"{dem_name}"
+        if dem_name == "glo_30":
+            tile_name = "Copernicus_DSM_COG_10_N34_00_W119_00_DEM.tif"
+        elif dem_name == "nasadem":
+            tile_name = "NASADEM_HGT_n34w119.tif"
         else:
-            NotImplementedError(f'Not implemented for {dem_name}')
+            NotImplementedError(f"Not implemented for {dem_name}")
         tile_path = dem_tile_dir / tile_name
         return rasterio.open(tile_path)
 
     return _get_tile_dataset
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def get_los_angeles_dummy_profile():
-
     def _get_dummy_profile(res: float):
         p_la = default_gtiff_profile.copy()
         t = Affine(res, 0, -118, 0, -res, 35)
-        p_la['transform'] = t
-        p_la['width'] = 10
-        p_la['height'] = 10
-        p_la['count'] = 1
-        p_la['crs'] = CRS.from_epsg(4326)
+        p_la["transform"] = t
+        p_la["width"] = 10
+        p_la["height"] = 10
+        p_la["count"] = 1
+        p_la["crs"] = CRS.from_epsg(4326)
         return p_la
 
     return _get_dummy_profile
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def get_tile_paths_for_comparison_with_golden_dataset():
-    golden_dataset_dir = Path(__file__).resolve().parent / 'data' / 'golden_datasets'
+    golden_dataset_dir = Path(__file__).resolve().parent / "data" / "golden_datasets"
 
     def _get_tile_dataset(location: str) -> list:
-        if location not in ['fairbanks', 'los_angeles']:
+        if location not in ["fairbanks", "los_angeles"]:
             raise NotImplementedError
-        dem_tile_dir = golden_dataset_dir / f'{location}_tiles'
-        paths = list(dem_tile_dir.glob('*.tif'))
+        dem_tile_dir = golden_dataset_dir / f"{location}_tiles"
+        paths = list(dem_tile_dir.glob("*.tif"))
         paths_str = list(map(str, paths))
         paths_str = sorted(paths_str)
         return paths_str
@@ -75,26 +74,26 @@ def get_tile_paths_for_comparison_with_golden_dataset():
     return _get_tile_dataset
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def get_golden_dataset_path():
-    golden_dataset_dir = Path(__file__).resolve().parent / 'data' / 'golden_datasets'
+    golden_dataset_dir = Path(__file__).resolve().parent / "data" / "golden_datasets"
 
     def _get_golden_dataset_path(location: str, hgt_type: str) -> str:
-        if location not in ['fairbanks', 'los_angeles']:
+        if location not in ["fairbanks", "los_angeles"]:
             raise NotImplementedError
-        return str(golden_dataset_dir / f'{location}_dem_{hgt_type}.tif')
+        return str(golden_dataset_dir / f"{location}_dem_{hgt_type}.tif")
 
     return _get_golden_dataset_path
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def get_geoid_for_golden_dataset_test():
-    golden_dataset_dir = Path(__file__).resolve().parent / 'data' / 'golden_datasets'
+    golden_dataset_dir = Path(__file__).resolve().parent / "data" / "golden_datasets"
 
     def _get_geoid(location: str) -> str:
-        if location not in ['fairbanks', 'los_angeles']:
+        if location not in ["fairbanks", "los_angeles"]:
             raise NotImplementedError
-        geoid_path = golden_dataset_dir / f'egm_08_{location}.tif'
+        geoid_path = golden_dataset_dir / f"egm_08_{location}.tif"
         with rasterio.open(geoid_path) as ds:
             X = ds.read(1)
             p = ds.profile

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,16 +5,16 @@ import pytest
 from dem_stitcher.datasets import get_overlapping_dem_tiles
 
 extents = [
-           # This is overlapping with Points/LineString for missing tiles
-           # See https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/issues/89#issuecomment-1399142499
-           [40.0, 36.0, 44.0, 40.0],
-           # Middle of Atlantic
-           [-46, 22, -45, 23]
-          ]
-dem_names = ['glo_90_missing', 'glo_30']
+    # This is overlapping with Points/LineString for missing tiles
+    # See https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/issues/89#issuecomment-1399142499
+    [40.0, 36.0, 44.0, 40.0],
+    # Middle of Atlantic
+    [-46, 22, -45, 23],
+]
+dem_names = ["glo_90_missing", "glo_30"]
 
 
-@pytest.mark.parametrize('extent, dem_name', zip(extents, dem_names))
+@pytest.mark.parametrize("extent, dem_name", zip(extents, dem_names))
 def test_empty_tiles(extent, dem_name):
     df_tiles = get_overlapping_dem_tiles(extent, dem_name)
     assert df_tiles.empty
@@ -24,8 +24,8 @@ def test_dateline_warning():
     extent_no_dateline = [-121.5, 34.95, -120.2, 36.25]
     with warnings.catch_warnings():
         warnings.simplefilter("error", category=UserWarning)
-        get_overlapping_dem_tiles(extent_no_dateline, 'glo_30')
+        get_overlapping_dem_tiles(extent_no_dateline, "glo_30")
 
     extent_with_dateline = [-181, 51.25, -179, 51.75]
     with pytest.warns(UserWarning):
-        get_overlapping_dem_tiles(extent_with_dateline, 'glo_30')
+        get_overlapping_dem_tiles(extent_with_dateline, "glo_30")

--- a/tests/test_dateline.py
+++ b/tests/test_dateline.py
@@ -1,21 +1,21 @@
 import pytest
 from numpy.testing import assert_almost_equal
 
-from dem_stitcher.dateline import (get_dateline_crossing,
-                                   split_extent_across_dateline)
+from dem_stitcher.dateline import get_dateline_crossing, split_extent_across_dateline
 from dem_stitcher.exceptions import DoubleDatelineCrossing, Incorrect4326Bounds
 from dem_stitcher.geoid import read_geoid
 from dem_stitcher.merge import merge_arrays_with_geometadata
 from dem_stitcher.rio_tools import translate_profile
 from dem_stitcher.stitcher import get_overlapping_dem_tiles, stitch_dem
 
-bounds_list = [[179, 52, 181, 53],
-               [179.1, -13, 180.001, -12.1],
-               [-181, 33, -179, 34.5],
-               [-180.1, -89, -178.8, -88],
-               [100, 0, 101, 1],
-               [-33, 10, -32, 12]
-               ]
+bounds_list = [
+    [179, 52, 181, 53],
+    [179.1, -13, 180.001, -12.1],
+    [-181, 33, -179, 34.5],
+    [-180.1, -89, -178.8, -88],
+    [100, 0, 101, 1],
+    [-33, 10, -32, 12],
+]
 crossings = [180, 180, -180, -180, 0, 0]
 
 
@@ -24,17 +24,20 @@ def test_dateline_crossing(bounds, crossing):
     assert get_dateline_crossing(bounds) == crossing
 
 
-bounds_list = [[-181, 0, 181, 1],
-               [-200, 0, -181, 1],
-               [180.01, 0, 200, 1],
-               [52, 89, 53, 91],
-               [52, -91, 53, -89],
-               ]
-exceptions = [DoubleDatelineCrossing,
-              Incorrect4326Bounds,
-              Incorrect4326Bounds,
-              Incorrect4326Bounds,
-              Incorrect4326Bounds]
+bounds_list = [
+    [-181, 0, 181, 1],
+    [-200, 0, -181, 1],
+    [180.01, 0, 200, 1],
+    [52, 89, 53, 91],
+    [52, -91, 53, -89],
+]
+exceptions = [
+    DoubleDatelineCrossing,
+    Incorrect4326Bounds,
+    Incorrect4326Bounds,
+    Incorrect4326Bounds,
+    Incorrect4326Bounds,
+]
 
 
 @pytest.mark.parametrize("bounds, exception", zip(bounds_list, exceptions))
@@ -43,25 +46,24 @@ def test_dateline_exceptions(bounds, exception):
         get_dateline_crossing(bounds)
 
 
-bounds_list = [[-180.25, 51.25, -179.75, 51.75],
-               [179.75, 51.25, 180.25, 51.75]]
-tiles_ids_list = [['Copernicus_DSM_COG_10_N51_00_E179_00_DEM', 'Copernicus_DSM_COG_10_N51_00_W180_00_DEM'],
-                  ['Copernicus_DSM_COG_10_N51_00_E179_00_DEM', 'Copernicus_DSM_COG_10_N51_00_W180_00_DEM']]
+bounds_list = [[-180.25, 51.25, -179.75, 51.75], [179.75, 51.25, 180.25, 51.75]]
+tiles_ids_list = [
+    ["Copernicus_DSM_COG_10_N51_00_E179_00_DEM", "Copernicus_DSM_COG_10_N51_00_W180_00_DEM"],
+    ["Copernicus_DSM_COG_10_N51_00_E179_00_DEM", "Copernicus_DSM_COG_10_N51_00_W180_00_DEM"],
+]
 
 
 @pytest.mark.parametrize("bounds, tile_ids", zip(bounds_list, tiles_ids_list))
 def test_get_tiles_across_dateline(bounds, tile_ids):
-    df_tiles_overlapping = get_overlapping_dem_tiles(bounds, 'glo_30')
+    df_tiles_overlapping = get_overlapping_dem_tiles(bounds, "glo_30")
     tile_ids_stitcher = df_tiles_overlapping.tile_id.tolist()
     # Stitcher should sort by tile id as is the case with the static tile lists above are
     assert tile_ids_stitcher == tile_ids
 
 
-bounds_list = [[-181, 51, -179, 52],
-               [-171, 51, -169, 52]]
+bounds_list = [[-181, 51, -179, 52], [-171, 51, -169, 52]]
 
-outputs = [([-180.0, 51.0, -179.0, 52.0], [179.0, 51.0, 180.0, 52.0]),
-           ([-171, 51, -169, 52], [])]
+outputs = [([-180.0, 51.0, -179.0, 52.0], [179.0, 51.0, 180.0, 52.0]), ([-171, 51, -169, 52], [])]
 
 
 @pytest.mark.parametrize("bounds, split_extent_known", zip(bounds_list, outputs))
@@ -70,33 +72,31 @@ def test_split_extent(bounds, split_extent_known):
     assert split_extent_output == split_extent_known
 
 
-bounds_list = [[-181, 51.25, -179, 51.75],
-               [179, 51, 181, 52]
-               ]
+bounds_list = [[-181, 51.25, -179, 51.75], [179, 51, 181, 52]]
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize("bounds", bounds_list)
 def test_stithcer_across_dateline(bounds):
-    X, _ = stitch_dem(bounds, 'glo_30', dst_ellipsoidal_height=True)
+    X, _ = stitch_dem(bounds, "glo_30", dst_ellipsoidal_height=True)
     assert len(X.shape) == 2
 
 
 @pytest.mark.integration
 def test_stitcher_across_dateline_approaching_from_left_and_right():
     bounds_l = [-181, 51.25, -179, 51.75]
-    X_l, p_l = stitch_dem(bounds_l, 'glo_30', dst_ellipsoidal_height=False, dst_area_or_point='Point')
+    X_l, p_l = stitch_dem(bounds_l, "glo_30", dst_ellipsoidal_height=False, dst_area_or_point="Point")
 
     bounds_r = [179, 51.25, 181, 51.75]
-    X_r, p_r = stitch_dem(bounds_r, 'glo_30', dst_ellipsoidal_height=False, dst_area_or_point='Point')
+    X_r, p_r = stitch_dem(bounds_r, "glo_30", dst_ellipsoidal_height=False, dst_area_or_point="Point")
 
     # Metadata should be the same after translation
-    res_x = p_r['transform'].a
+    res_x = p_r["transform"].a
     p_r_t = translate_profile(p_r, -360 / res_x, 0)
 
     # Georefernencing
-    assert p_r_t['crs'] == p_l['crs']
-    assert p_r_t['transform'] == p_l['transform']
+    assert p_r_t["crs"] == p_l["crs"]
+    assert p_r_t["transform"] == p_l["transform"]
 
     # Arrays should be the same as well
     assert_almost_equal(X_r, X_l, 5)
@@ -105,18 +105,17 @@ def test_stitcher_across_dateline_approaching_from_left_and_right():
 @pytest.mark.integration
 def test_read_geoid_across_dateline():
     bounds = [-181, 51.25, -179, 51.75]
-    geoid_arr_dateline, p = read_geoid('egm_08', bounds, res_buffer=1)
+    geoid_arr_dateline, p = read_geoid("egm_08", bounds, res_buffer=1)
 
     bounds_l = [-179.999, 51.25, -179, 51.75]
-    geoid_arr_l, p_l = read_geoid('egm_08', bounds_l, res_buffer=1)
+    geoid_arr_l, p_l = read_geoid("egm_08", bounds_l, res_buffer=1)
 
     bounds_r = [179, 51.25, 179.999, 51.75]
-    geoid_arr_r, p_r = read_geoid('egm_08', bounds_r, res_buffer=1)
+    geoid_arr_r, p_r = read_geoid("egm_08", bounds_r, res_buffer=1)
 
-    res_x = p_r['transform'].a
+    res_x = p_r["transform"].a
     p_r_t = translate_profile(p_r, -360 / res_x, 0)
 
-    geoid_merged, _ = merge_arrays_with_geometadata([geoid_arr_l, geoid_arr_r],
-                                                    [p_l, p_r_t])
+    geoid_merged, _ = merge_arrays_with_geometadata([geoid_arr_l, geoid_arr_r], [p_l, p_r_t])
 
     assert_almost_equal(geoid_merged, geoid_arr_dateline, 5)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,29 +1,25 @@
 import pytest
 
 from dem_stitcher import stitch_dem
-from dem_stitcher.exceptions import (DEMNotSupported, Incorrect4326Bounds,
-                                     NoDEMCoverage)
+from dem_stitcher.exceptions import DEMNotSupported, Incorrect4326Bounds, NoDEMCoverage
 
 
 def test_dem_not_supported():
     with pytest.raises(DEMNotSupported):
         bounds = [-120, 34, -119, 35]
 
-        X, p = stitch_dem(bounds,
-                          dem_name='dem-not-supported')
+        X, p = stitch_dem(bounds, dem_name="dem-not-supported")
 
 
 def test_no_coverage():
     with pytest.raises(NoDEMCoverage):
         # Middle of the Atlantic
         bounds = [-46, 22, -45, 23]
-        X, p = stitch_dem(bounds,
-                          dem_name='glo_30')
+        X, p = stitch_dem(bounds, dem_name="glo_30")
 
 
 def test_bad_extents():
     with pytest.raises(Incorrect4326Bounds):
         bounds = [-119, 34, -120, 35]
 
-        X, p = stitch_dem(bounds,
-                          dem_name='glo_30')
+        X, p = stitch_dem(bounds, dem_name="glo_30")

--- a/tests/test_geoid.py
+++ b/tests/test_geoid.py
@@ -11,11 +11,11 @@ from dem_stitcher.rio_tools import reproject_arr_to_match_profile
 
 def test_read_geoid():
     # entire geoid
-    X_all, p_all = read_geoid('geoid_18')
+    X_all, p_all = read_geoid("geoid_18")
 
     # Over Los Angeles
     la_bounds = [-118.8, 34.6, -118.5, 34.8]
-    X_sub, p_sub = read_geoid('geoid_18', extent=la_bounds, res_buffer=1)
+    X_sub, p_sub = read_geoid("geoid_18", extent=la_bounds, res_buffer=1)
 
     X_sub_r, p_r = reproject_arr_to_match_profile(X_sub, p_sub, p_all)
 
@@ -24,10 +24,10 @@ def test_read_geoid():
     data_all = X_all[~mask]
 
     assert_array_equal(data_sub, data_all)
-    assert p_r['transform'] == p_all['transform']
+    assert p_r["transform"] == p_all["transform"]
 
 
-@pytest.mark.parametrize("dem_res", [.001, .01, .1, 1])
+@pytest.mark.parametrize("dem_res", [0.001, 0.01, 0.1, 1])
 def test_remove_geoid(get_los_angeles_dummy_profile, dem_res):
     """
     We test removing a geoid against a zero array, which should literally be the entire geoid array
@@ -37,24 +37,24 @@ def test_remove_geoid(get_los_angeles_dummy_profile, dem_res):
     of the geoid array.
     """
     p_ref = get_los_angeles_dummy_profile(res=dem_res)
-    X_geoid, p_geoid = read_geoid('geoid_18')
+    X_geoid, p_geoid = read_geoid("geoid_18")
 
     res_buffer_default = 2
 
     X_sub, _ = reproject_arr_to_match_profile(X_geoid, p_geoid, p_ref)
 
     Y = np.zeros((10, 10), dtype=np.float32)
-    if dem_res >= .1:
-        geoid_res = p_geoid['transform'].a
+    if dem_res >= 0.1:
+        geoid_res = p_geoid["transform"].a
         with pytest.warns(UserWarning):
-            _ = remove_geoid(Y, p_ref, 'geoid_18')
+            _ = remove_geoid(Y, p_ref, "geoid_18")
 
-        res_buffer_updated = (int(np.ceil(dem_res / geoid_res)))
+        res_buffer_updated = int(np.ceil(dem_res / geoid_res))
         assert res_buffer_default < res_buffer_updated
 
-        X_sub_2 = remove_geoid(Y, p_ref, 'geoid_18', res_buffer=res_buffer_updated)
+        X_sub_2 = remove_geoid(Y, p_ref, "geoid_18", res_buffer=res_buffer_updated)
 
     else:
-        X_sub_2 = remove_geoid(Y, p_ref, 'geoid_18', res_buffer=res_buffer_default)
+        X_sub_2 = remove_geoid(Y, p_ref, "geoid_18", res_buffer=res_buffer_default)
 
     assert_array_equal(X_sub_2, X_sub)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -47,43 +47,38 @@ LR) xmin, ymin, xmax, ymax = 20, -20, 30, -10
 """
 
 extents = [
-           [10, -20, 30, 0],            # Full extents of image
-           [10.5, -19.5, 29.5, -.5],    # within .5 degrees of image
-           [11.5, -18.5, 28.5, -1.5],   # within 1.5 degrees of image
-           [10.5, -9.5, 19.5, -.5],     # within .5 of top left corner (see UL above)
-           [10, -10, 30, 0],            # Upper part of image
-          ]
+    [10, -20, 30, 0],  # Full extents of image
+    [10.5, -19.5, 29.5, -0.5],  # within .5 degrees of image
+    [11.5, -18.5, 28.5, -1.5],  # within 1.5 degrees of image
+    [10.5, -9.5, 19.5, -0.5],  # within .5 of top left corner (see UL above)
+    [10, -10, 30, 0],  # Upper part of image
+]
 
 ref = np.zeros((20, 20))
 ref[1:, 1:] = 1
 ref[2:, 2:] = 2
 ref[10:, 10:] = np.nan
-arrays = [ref,
-          ref,
-          ref[1:19, 1:19],
-          ref[:10, :10],
-          ref[:10, :]
-          ]
+arrays = [ref, ref, ref[1:19, 1:19], ref[:10, :10], ref[:10, :]]
 
 # Using upper left corner (10, 0) because (0, 0) raises warnings about (0, 0)
 t = Affine(1, 0, 10, 0, -1, 0)
-transforms = [t,                           # reference transform
-              t,
-              t.translation(1, -1) * t,    # transform with UL corner at (11, -1)
-              t,
-              t
-              ]
+transforms = [
+    t,  # reference transform
+    t,
+    t.translation(1, -1) * t,  # transform with UL corner at (11, -1)
+    t,
+    t,
+]
 
 
 @pytest.mark.parametrize("extent, array, transform", zip(extents, arrays, transforms))
 def test_merge_tiles(test_data_dir, extent, array, transform):
-    merge_dir = test_data_dir / 'stitcher' / 'merge_tiles'
-    upper_left = merge_dir / 'ul.tif'
-    upper_right = merge_dir / 'ur.tif'
-    bottom_left = merge_dir / 'bl.tif'
+    merge_dir = test_data_dir / "stitcher" / "merge_tiles"
+    upper_left = merge_dir / "ul.tif"
+    upper_right = merge_dir / "ur.tif"
+    bottom_left = merge_dir / "bl.tif"
 
-    tile_datasets = [rasterio.open(path)
-                     for path in [upper_left, upper_right, bottom_left]]
+    tile_datasets = [rasterio.open(path) for path in [upper_left, upper_right, bottom_left]]
 
     X, p = merge_tile_datasets_within_extent(tile_datasets, extent)
 
@@ -91,4 +86,4 @@ def test_merge_tiles(test_data_dir, extent, array, transform):
 
     array = array[np.newaxis, ...]
     assert_array_equal(X, array)
-    assert p['transform'] == transform
+    assert p["transform"] == transform

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -7,13 +7,13 @@ from dem_stitcher.merge import merge_arrays_with_geometadata
 from dem_stitcher.stitcher import intersects_missing_glo_30_tiles
 
 extents = [
-           # On boundary of missing tiles (both glo-90, glo-30)
-           [42.95, 40.45, 43.05, 40.55],
-           # Contained within missing tiles
-           [43.95, 40.45, 44.05, 40.55],
-           # Outside
-           [41.95, 40.45, 42.05, 40.55],
-           ]
+    # On boundary of missing tiles (both glo-90, glo-30)
+    [42.95, 40.45, 43.05, 40.55],
+    # Contained within missing tiles
+    [43.95, 40.45, 44.05, 40.55],
+    # Outside
+    [41.95, 40.45, 42.05, 40.55],
+]
 
 containment = [True, True, False]
 
@@ -25,48 +25,48 @@ def _open_one(path):
     return X, p
 
 
-@pytest.mark.parametrize('extent, containment', zip(extents, containment))
+@pytest.mark.parametrize("extent, containment", zip(extents, containment))
 def test_intersects_missing_tiles(extent, containment):
     assert intersects_missing_glo_30_tiles(extent) == containment
 
 
 def test_merge_glo30_and_glo_90(test_data_dir):
-    data_dir = test_data_dir / 'missing'
-    glo_30_left_path = data_dir / 'glo_30_left.tif'
-    glo_90_right_path = data_dir / 'glo_90_right.tif'
-    glo_merged_path = data_dir / 'glo_merged.tif'
+    data_dir = test_data_dir / "missing"
+    glo_30_left_path = data_dir / "glo_30_left.tif"
+    glo_90_right_path = data_dir / "glo_90_right.tif"
+    glo_merged_path = data_dir / "glo_merged.tif"
 
     X_glo_30, p_glo_30 = _open_one(glo_30_left_path)
     X_glo_90, p_glo_90 = _open_one(glo_90_right_path)
     X_merged, p_merged = _open_one(glo_merged_path)
 
-    X_merged_out, p_merged_out = merge_arrays_with_geometadata([X_glo_30, X_glo_90],
-                                                               [p_glo_30, p_glo_90])
+    X_merged_out, p_merged_out = merge_arrays_with_geometadata([X_glo_30, X_glo_90], [p_glo_30, p_glo_90])
 
     assert_almost_equal(X_merged, X_merged_out[0, ...], decimal=6)
-    assert p_merged_out['transform'] == p_merged['transform']
+    assert p_merged_out["transform"] == p_merged["transform"]
 
 
 @pytest.mark.integration
 def test_glo_90_filling(test_data_dir):
-
-    data_dir = test_data_dir / 'missing'
-    glo_merged_path = data_dir / 'glo_merged.tif'
+    data_dir = test_data_dir / "missing"
+    glo_merged_path = data_dir / "glo_merged.tif"
 
     # Parameters for stitching
-    dst_area_or_point = 'Point'
+    dst_area_or_point = "Point"
     dst_ellipsoidal_height = False
-    dem_name = 'glo_30'
+    dem_name = "glo_30"
 
     bounds = [42.95, 40.45, 43.05, 40.55]
 
-    X_filled, p_filled = stitch_dem(bounds,
-                                    dem_name=dem_name,
-                                    dst_ellipsoidal_height=dst_ellipsoidal_height,
-                                    dst_area_or_point=dst_area_or_point,
-                                    fill_in_glo_30=True)
+    X_filled, p_filled = stitch_dem(
+        bounds,
+        dem_name=dem_name,
+        dst_ellipsoidal_height=dst_ellipsoidal_height,
+        dst_area_or_point=dst_area_or_point,
+        fill_in_glo_30=True,
+    )
 
     X_merged, p_merged = _open_one(glo_merged_path)
 
     assert_almost_equal(X_merged, X_filled, decimal=6)
-    assert p_filled['transform'] == p_merged['transform']
+    assert p_filled["transform"] == p_merged["transform"]

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -2,33 +2,30 @@ from pathlib import Path
 
 import pytest
 
-notebooks = ['Basic_Demo.ipynb',
-             'Comparing_DEMs.ipynb',
-             'Filling_in_missing_glo-30_tiles_with_glo-90_tiles.ipynb',
-             'Merging_DEM_Tiles_into_a_VRT.ipynb'
-             ]
+notebooks = [
+    "Basic_Demo.ipynb",
+    "Comparing_DEMs.ipynb",
+    "Filling_in_missing_glo-30_tiles_with_glo-90_tiles.ipynb",
+    "Merging_DEM_Tiles_into_a_VRT.ipynb",
+]
 
 
 @pytest.mark.integration
 @pytest.mark.notebook
-@pytest.mark.parametrize('notebook_file_name', notebooks)
-def test_read_geoid_across_dateline(notebooks_dir,
-                                    test_data_dir,
-                                    notebook_file_name):
-
+@pytest.mark.parametrize("notebook_file_name", notebooks)
+def test_read_geoid_across_dateline(notebooks_dir, test_data_dir, notebook_file_name):
     import papermill as pm
 
     test_dir = test_data_dir.parent
-    out_dir = test_dir / 'out_test_nb'
+    out_dir = test_dir / "out_test_nb"
     out_dir.mkdir(exist_ok=True, parents=True)
     parameters = {}
 
-    if notebook_file_name == 'Basic_Demo.ipynb':
-        out_tif_dir = Path(test_dir) / 'out'
+    if notebook_file_name == "Basic_Demo.ipynb":
+        out_tif_dir = Path(test_dir) / "out"
         out_tif_dir.mkdir(exist_ok=True, parents=True)
         parameters = dict(out_directory_name=str(out_tif_dir))
 
-    pm.execute_notebook(notebooks_dir / notebook_file_name,
-                        output_path=(out_dir / notebook_file_name),
-                        parameters=parameters
-                        )
+    pm.execute_notebook(
+        notebooks_dir / notebook_file_name, output_path=(out_dir / notebook_file_name), parameters=parameters
+    )

--- a/tests/test_rio_tools.py
+++ b/tests/test_rio_tools.py
@@ -1,9 +1,7 @@
 import rasterio
 from numpy.testing import assert_almost_equal
 
-from dem_stitcher.rio_tools import (reproject_arr_to_match_profile,
-                                    translate_dataset,
-                                    update_profile_resolution)
+from dem_stitcher.rio_tools import reproject_arr_to_match_profile, translate_dataset, update_profile_resolution
 
 
 def test_update_resolution(test_data_dir):
@@ -11,43 +9,40 @@ def test_update_resolution(test_data_dir):
     resamples
     """
 
-    data_dir = test_data_dir / 'rio_tools' / 'update_resolution'
+    data_dir = test_data_dir / "rio_tools" / "update_resolution"
     assert data_dir.exists()
 
-    with rasterio.open(data_dir / 'res_one_deg.tif') as ds:
+    with rasterio.open(data_dir / "res_one_deg.tif") as ds:
         p_one_deg = ds.profile
         X_one_deg = ds.read(1)
         res_one_deg = ds.res
 
-    with rasterio.open(data_dir / 'res_quarter_deg.tif') as ds:
+    with rasterio.open(data_dir / "res_quarter_deg.tif") as ds:
         p_quarter_deg = ds.profile
         X_quarter_deg = ds.read(1)
         res_quarter_deg = ds.res
 
-    t_one_deg = p_one_deg['transform']
-    t_quarter_deg = p_quarter_deg['transform']
+    t_one_deg = p_one_deg["transform"]
+    t_quarter_deg = p_quarter_deg["transform"]
     assert (t_one_deg * (0, 0)) == (t_quarter_deg * (0, 0))
     assert res_one_deg == (1, 1)
-    assert res_quarter_deg == (.25, .25)
+    assert res_quarter_deg == (0.25, 0.25)
 
-    p_higher_res = update_profile_resolution(p_one_deg, .25)
-    X_quarter_deg_reprj, _ = reproject_arr_to_match_profile(X_one_deg,
-                                                            p_one_deg,
-                                                            p_higher_res,
-                                                            resampling='bilinear')
+    p_higher_res = update_profile_resolution(p_one_deg, 0.25)
+    X_quarter_deg_reprj, _ = reproject_arr_to_match_profile(X_one_deg, p_one_deg, p_higher_res, resampling="bilinear")
     X_quarter_deg_reprj = X_quarter_deg_reprj[0, ...]
 
     assert_almost_equal(X_quarter_deg_reprj, X_quarter_deg, 5)
-    assert t_quarter_deg == p_higher_res['transform']
+    assert t_quarter_deg == p_higher_res["transform"]
 
 
 def test_dataset_translation(test_data_dir):
-    data_dir = test_data_dir / 'dateline' / 'translate_datasets'
+    data_dir = test_data_dir / "dateline" / "translate_datasets"
 
     assert data_dir.exists()
 
-    ds_left = rasterio.open(data_dir / 'left.tif')
-    ds_right = rasterio.open(data_dir / 'right.tif')
+    ds_left = rasterio.open(data_dir / "left.tif")
+    ds_right = rasterio.open(data_dir / "right.tif")
 
     res_x = ds_left.res[0]
     mfile, ds_left_t = translate_dataset(ds_left, 360 / res_x, 0)

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -10,10 +10,8 @@ from shapely.geometry import box
 from dem_stitcher import get_dem_tile_paths, stitch_dem
 from dem_stitcher.datasets import DATASETS
 from dem_stitcher.geoid import read_geoid
-from dem_stitcher.rio_tools import (reproject_arr_to_match_profile,
-                                    translate_profile)
-from dem_stitcher.stitcher import (merge_and_transform_dem_tiles,
-                                   shift_profile_for_pixel_loc)
+from dem_stitcher.rio_tools import reproject_arr_to_match_profile, translate_profile
+from dem_stitcher.stitcher import merge_and_transform_dem_tiles, shift_profile_for_pixel_loc
 
 
 """
@@ -24,44 +22,35 @@ Simple test to check if translation is done correctly
 All permutations of Area (or UL corner valued/gdal default) and Point (or pixel-centered, which is what SRTM uses)
 """
 
-src_tags = ['Area',
-            'Area',
-            'Point',
-            'Point'
-            ]
+src_tags = ["Area", "Area", "Point", "Point"]
 
-dst_tags = ['Area',
-            'Point',
-            'Point',
-            'Area'
-            ]
+dst_tags = ["Area", "Point", "Point", "Area"]
 
 t = Affine(1, 0, 10, 0, -1, 0)
 transforms = [
-              t,
-              Affine(1, 0, 9.5, 0, -1, 0.5),
-              t,
-              Affine(1, 0, 10.5, 0, -1, -0.5),
-              ]
+    t,
+    Affine(1, 0, 9.5, 0, -1, 0.5),
+    t,
+    Affine(1, 0, 10.5, 0, -1, -0.5),
+]
 
 
 @pytest.mark.parametrize("src_tag, dst_tag, transform_expected", zip(src_tags, dst_tags, transforms))
 def test_shift_pixel_loc(src_tag, dst_tag, transform_expected):
-
     # Create dummy profile with reference transform
     p = default_gtiff_profile.copy()
     t_ref = Affine(1, 0, 10, 0, -1, 0)
-    p['transform'] = t_ref
+    p["transform"] = t_ref
 
     # Translate if necessary
     p_new = shift_profile_for_pixel_loc(p, src_tag, dst_tag)
-    t_new = p_new['transform']
+    t_new = p_new["transform"]
 
     # Check the transform is what we expect
     assert transform_expected == t_new
 
 
-@pytest.mark.parametrize("dem_name", ['glo_30', 'nasadem'])
+@pytest.mark.parametrize("dem_name", ["glo_30", "nasadem"])
 def test_no_change_when_no_transformations_to_tile(get_los_angeles_tile_dataset, dem_name):
     """Opens a single glo tile, selects bounds contained inside of it and then reprojects the obtained tile back into
     the tiles original frame to determine if modifications were made.
@@ -72,18 +61,18 @@ def test_no_change_when_no_transformations_to_tile(get_los_angeles_tile_dataset,
 
     # Within the Los Angeles tile
     bounds = [-118.8, 34.6, -118.5, 34.8]
-    X_sub, p_sub = merge_and_transform_dem_tiles(datasets,
-                                                 bounds,
-                                                 dem_name=dem_name,
-                                                 # Do not modify tile
-                                                 dst_ellipsoidal_height=False,
-                                                 dst_area_or_point='Point')
+    X_sub, p_sub = merge_and_transform_dem_tiles(
+        datasets,
+        bounds,
+        dem_name=dem_name,
+        # Do not modify tile
+        dst_ellipsoidal_height=False,
+        dst_area_or_point="Point",
+    )
 
     datasets[0].close()
 
-    X_sub_r, _ = reproject_arr_to_match_profile(X_sub, p_sub, p_tile,
-                                                num_threads=5,
-                                                resampling='nearest')
+    X_sub_r, _ = reproject_arr_to_match_profile(X_sub, p_sub, p_tile, num_threads=5, resampling="nearest")
     X_sub_r = X_sub_r[0, ...]
 
     # The subset will have nan values so only compare areas with nan values
@@ -98,34 +87,28 @@ def test_no_change_when_no_transformations_to_tile(get_los_angeles_tile_dataset,
 @pytest.mark.integration
 @pytest.mark.parametrize("dem_name", DATASETS)
 def test_download_dem(dem_name):
-    if dem_name == 'glo_90_missing':
+    if dem_name == "glo_90_missing":
         # Missing area
         bounds = [45.5, 39.5, 46.5, 40.5]
     else:
         # Within the Los Angeles tile
         bounds = [-118.8, 34.6, -118.5, 34.8]
 
-    dem_arr, p = stitch_dem(bounds,
-                            dem_name,
-                            n_threads_downloading=5,
-                            dst_ellipsoidal_height=True,
-                            dst_resolution=0.0002777777777777777775
-                            )
+    dem_arr, p = stitch_dem(
+        bounds, dem_name, n_threads_downloading=5, dst_ellipsoidal_height=True, dst_resolution=0.0002777777777777777775
+    )
     assert len(dem_arr.shape) == 2
-    assert np.isnan(p['nodata'])
+    assert np.isnan(p["nodata"])
 
 
 def test_boundary_of_missing_glo_30_data():
     # See https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/issues/89#issuecomment-1399142499
     bounds = [42.0, 37.0, 44.0, 39.0]
-    dem_arr, p = stitch_dem(bounds,
-                            'glo_30',
-                            n_threads_downloading=5,
-                            dst_ellipsoidal_height=True,
-                            dst_resolution=0.0002777777777777777775
-                            )
+    dem_arr, p = stitch_dem(
+        bounds, "glo_30", n_threads_downloading=5, dst_ellipsoidal_height=True, dst_resolution=0.0002777777777777777775
+    )
     assert len(dem_arr.shape) == 2
-    assert np.isnan(p['nodata'])
+    assert np.isnan(p["nodata"])
 
 
 @pytest.mark.integration
@@ -133,24 +116,28 @@ def test_mask_differences_with_merge_nodata_values_without_ellipsoidal():
     # Aleutian tiles follow chain so there is lots of nodata
     aleutian_bounds = [-167.5, 53.5, -164.5, 54.5]
 
-    X_nan, p_nan = stitch_dem(aleutian_bounds,
-                              dem_name='glo_30',
-                              dst_ellipsoidal_height=False,
-                              dst_area_or_point='Point',
-                              merge_nodata_value=np.nan)
+    X_nan, p_nan = stitch_dem(
+        aleutian_bounds,
+        dem_name="glo_30",
+        dst_ellipsoidal_height=False,
+        dst_area_or_point="Point",
+        merge_nodata_value=np.nan,
+    )
 
-    X_zero, p_zero = stitch_dem(aleutian_bounds,
-                                dem_name='glo_30',
-                                dst_ellipsoidal_height=False,
-                                dst_area_or_point='Point',
-                                merge_nodata_value=0)
+    X_zero, p_zero = stitch_dem(
+        aleutian_bounds,
+        dem_name="glo_30",
+        dst_ellipsoidal_height=False,
+        dst_area_or_point="Point",
+        merge_nodata_value=0,
+    )
 
     assert X_zero.shape == X_nan.shape
-    assert p_nan['transform'] == p_zero['transform']
-    assert np.isnan(p_zero['nodata'])
+    assert p_nan["transform"] == p_zero["transform"]
+    assert np.isnan(p_zero["nodata"])
 
     mask_nan = np.isnan(X_nan)
-    mask_zero = (X_zero == 0)
+    mask_zero = X_zero == 0
 
     # There may be zeros within the tiles so we check a containment of masks
     # Checks if all elements in mask_zero are True where mask_nan
@@ -166,22 +153,22 @@ def test_mask_differences_with_merge_nodata_values_with_ellipsoidal():
     # Aleutian tiles follow chain so there is lots of nodata
     aleutian_bounds = [-167.5, 53.5, -164.5, 54.5]
 
-    X_nan, p_nan = stitch_dem(aleutian_bounds,
-                              dem_name='glo_30',
-                              dst_ellipsoidal_height=True,
-                              dst_area_or_point='Point',
-                              merge_nodata_value=np.nan)
+    X_nan, p_nan = stitch_dem(
+        aleutian_bounds,
+        dem_name="glo_30",
+        dst_ellipsoidal_height=True,
+        dst_area_or_point="Point",
+        merge_nodata_value=np.nan,
+    )
     # Need to use nan mask to get all nodata areas with respect to tiles
     mask_nan = np.isnan(X_nan)
 
-    X_zero, _ = stitch_dem(aleutian_bounds,
-                           dem_name='glo_30',
-                           dst_ellipsoidal_height=True,
-                           dst_area_or_point='Point',
-                           merge_nodata_value=0)
+    X_zero, _ = stitch_dem(
+        aleutian_bounds, dem_name="glo_30", dst_ellipsoidal_height=True, dst_area_or_point="Point", merge_nodata_value=0
+    )
 
-    X_geoid, p_geoid = read_geoid('egm_08', aleutian_bounds, res_buffer=5)
-    p_geoid = translate_profile(p_geoid, -.5, -.5)
+    X_geoid, p_geoid = read_geoid("egm_08", aleutian_bounds, res_buffer=5)
+    p_geoid = translate_profile(p_geoid, -0.5, -0.5)
 
     X_geoid_r, _ = reproject_arr_to_match_profile(X_geoid, p_geoid, p_nan)
     X_geoid_r = X_geoid_r[0, ...]
@@ -191,21 +178,16 @@ def test_mask_differences_with_merge_nodata_values_with_ellipsoidal():
 
 def test_bad_merge_nodata_value():
     with pytest.raises(ValueError):
-        stitch_dem([-118.8, 34.6, -118.5, 34.8],
-                   dem_name='glo_30',
-                   merge_nodata_value=3)
+        stitch_dem([-118.8, 34.6, -118.5, 34.8], dem_name="glo_30", merge_nodata_value=3)
 
 
 @pytest.mark.integration
 def test_get_dem_tile_paths_and_output_vrt(test_dir):
     input_bounds = [-121.5, 34.95, -120.2, 36.25]
-    dem_name = 'glo_30'
+    dem_name = "glo_30"
 
-    dem_tile_paths = get_dem_tile_paths(bounds=input_bounds,
-                                        dem_name=dem_name,
-                                        localize_tiles_to_gtiff=False
-                                        )
-    vrt_path = str(test_dir / f'test_{dem_name}.vrt')
+    dem_tile_paths = get_dem_tile_paths(bounds=input_bounds, dem_name=dem_name, localize_tiles_to_gtiff=False)
+    vrt_path = str(test_dir / f"test_{dem_name}.vrt")
     ds = gdal.BuildVRT(vrt_path, dem_tile_paths)
     ds = None
 
@@ -216,26 +198,29 @@ def test_get_dem_tile_paths_and_output_vrt(test_dir):
     assert output_geo.contains(input_geo)
 
 
-@pytest.mark.parametrize("hgt_type", ['geoid', 'ellipsoid'])
-@pytest.mark.parametrize("location", ['los_angeles', 'fairbanks'])
-def test_against_golden_datasets(location: str,
-                                 hgt_type: str,
-                                 get_tile_paths_for_comparison_with_golden_dataset,
-                                 get_golden_dataset_path,
-                                 get_geoid_for_golden_dataset_test,
-                                 mocker):
-    if location == 'los_angeles':
+@pytest.mark.parametrize("hgt_type", ["geoid", "ellipsoid"])
+@pytest.mark.parametrize("location", ["los_angeles", "fairbanks"])
+def test_against_golden_datasets(
+    location: str,
+    hgt_type: str,
+    get_tile_paths_for_comparison_with_golden_dataset,
+    get_golden_dataset_path,
+    get_geoid_for_golden_dataset_test,
+    mocker,
+):
+    if location == "los_angeles":
         bounds = [-118.05, 33.95, -117.95, 34.05]
         dst_resolution = None
-    if location == 'fairbanks':
+    if location == "fairbanks":
         bounds = [-147.75, 64.75, -147.65, 64.85]
-        dst_resolution = .0002777777
+        dst_resolution = 0.0002777777
 
-    mocker.patch('dem_stitcher.stitcher.get_dem_tile_paths',
-                 side_effect=[get_tile_paths_for_comparison_with_golden_dataset(location)])
+    mocker.patch(
+        "dem_stitcher.stitcher.get_dem_tile_paths",
+        side_effect=[get_tile_paths_for_comparison_with_golden_dataset(location)],
+    )
 
-    mocker.patch('dem_stitcher.geoid.read_geoid',
-                 side_effect=[get_geoid_for_golden_dataset_test(location)])
+    mocker.patch("dem_stitcher.geoid.read_geoid", side_effect=[get_geoid_for_golden_dataset_test(location)])
 
     path_golden = get_golden_dataset_path(location, hgt_type)
 
@@ -243,11 +228,12 @@ def test_against_golden_datasets(location: str,
         X_golden = ds.read(1)
         transform_golden = ds.transform
 
-    X, p = stitch_dem(bounds,
-                      dem_name='glo_30',
-                      dst_ellipsoidal_height=(hgt_type == 'ellipsoid'),
-                      dst_area_or_point='Point',
-                      dst_resolution=dst_resolution
-                      )
+    X, p = stitch_dem(
+        bounds,
+        dem_name="glo_30",
+        dst_ellipsoidal_height=(hgt_type == "ellipsoid"),
+        dst_area_or_point="Point",
+        dst_resolution=dst_resolution,
+    )
     assert_almost_equal(X_golden, X, decimal=7)
-    assert transform_golden == p['transform']
+    assert transform_golden == p["transform"]

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -9,9 +9,7 @@ from rasterio.windows import bounds as get_window_bounds
 from shapely.geometry import box
 
 from dem_stitcher.geoid import read_geoid
-from dem_stitcher.rio_window import (get_indices_from_extent,
-                                     get_window_from_extent,
-                                     read_raster_from_window)
+from dem_stitcher.rio_window import get_indices_from_extent, get_window_from_extent, read_raster_from_window
 
 """
 This does a simple test of window reading over an extent of the following area:
@@ -48,71 +46,61 @@ If we start at (8.5, 1.5) and go for 7 degrees similarly, then we should get:
 ref = np.zeros((10, 10))
 ref[1:9, 1:9] = 1
 ref[2:8, 2:8] = 2
-arrays = [ref,
-          ref,
-          ref[1:9, 1:9],
-          ref[2:8, 2:8],
-          ref[1:9, 2:8]
-          ]
+arrays = [ref, ref, ref[1:9, 1:9], ref[2:8, 2:8], ref[1:9, 2:8]]
 
 
 # Using upper left corner (10, 0) because (0, 0) raises warnings being the identify affine transformation
 t = Affine(1, 0, 10, 0, -1, 0)
-transforms = [t,                           # reference transform
-              t,                           # reference transform
-              t.translation(1, -1) * t,    # transform with UL corner at (11, -1)
-              t.translation(2, -2) * t,    # trasnform with UL corner at (12, -2)
-              t.translation(2, -1) * t]    # trasnform with UL corner at (12, -1)
+transforms = [
+    t,  # reference transform
+    t,  # reference transform
+    t.translation(1, -1) * t,  # transform with UL corner at (11, -1)
+    t.translation(2, -2) * t,  # trasnform with UL corner at (12, -2)
+    t.translation(2, -1) * t,
+]  # trasnform with UL corner at (12, -1)
 
 
 extents = [
-            [9.5, -10.5, 20.5, .5],     # beyond the reference image extent by .5 degrees
-            [10.5, -9.5, 19.5, -.5],    # .5 degree within reference image
-            [11.5, -8.5, 18.5, -1.5],   # 1.5 degree within reference image
-            [12.5, -7.5, 17.5, -2.5],   # 2.5 degree within reference image
-            [12.5, -8.5, 17.5, -1.5]    # 2.5 degree within x-axis and 1.5 within y-axis of reference
-           ]
+    [9.5, -10.5, 20.5, 0.5],  # beyond the reference image extent by .5 degrees
+    [10.5, -9.5, 19.5, -0.5],  # .5 degree within reference image
+    [11.5, -8.5, 18.5, -1.5],  # 1.5 degree within reference image
+    [12.5, -7.5, 17.5, -2.5],  # 2.5 degree within reference image
+    [12.5, -8.5, 17.5, -1.5],  # 2.5 degree within x-axis and 1.5 within y-axis of reference
+]
 
 
 @pytest.mark.parametrize("extent, array, transform", zip(extents, arrays, transforms))
 def test_read_window_4326(test_data_dir, extent, array, transform):
-    raster_path = test_data_dir / 'rio_window' / 'test_window.tif'
+    raster_path = test_data_dir / "rio_window" / "test_window.tif"
 
-    window_arr, p = read_raster_from_window(raster_path,
-                                            extent,
-                                            CRS.from_epsg(4326),
-                                            res_buffer=0)
+    window_arr, p = read_raster_from_window(raster_path, extent, CRS.from_epsg(4326), res_buffer=0)
     array_gdal_format = array[np.newaxis, ...]
     assert_array_equal(array_gdal_format, window_arr)
-    assert transform == p['transform']
+    assert transform == p["transform"]
 
 
 @pytest.mark.parametrize("geojson_index, array, transform", zip([0, 1, 2, 3], arrays, transforms))
 def test_read_window_utm(test_data_dir, geojson_index, array, transform):
-    """Same test using bounds that have been reprojected into an appropriate UTM zone. Ignores index 4.
-    """
-    raster_path = test_data_dir / 'rio_window' / 'test_window.tif'
-    geojson_path = test_data_dir / 'rio_window' / f'window_utm_{geojson_index}.geojson'
+    """Same test using bounds that have been reprojected into an appropriate UTM zone. Ignores index 4."""
+    raster_path = test_data_dir / "rio_window" / "test_window.tif"
+    geojson_path = test_data_dir / "rio_window" / f"window_utm_{geojson_index}.geojson"
 
     df = gpd.read_file(geojson_path)
     extent = list(df.total_bounds)
     crs = df.crs
 
-    window_arr, p = read_raster_from_window(raster_path,
-                                            extent,
-                                            crs,
-                                            res_buffer=0)
+    window_arr, p = read_raster_from_window(raster_path, extent, crs, res_buffer=0)
     array_gdal_format = array[np.newaxis, ...]
     assert_array_equal(array_gdal_format, window_arr)
-    assert transform == p['transform']
+    assert transform == p["transform"]
 
 
 @pytest.mark.parametrize("geojson_index, array, transform", zip([0, 1, 2, 3], arrays, transforms))
 def test_get_window_obj_utm(test_data_dir, geojson_index, array, transform):
     """Checks the window's bounds contains the input extent once intersected with the rasters (sometimes the extent
     can go beyond the raster)"""
-    raster_path = test_data_dir / 'rio_window' / 'test_window.tif'
-    geojson_path = test_data_dir / 'rio_window' / f'window_utm_{geojson_index}.geojson'
+    raster_path = test_data_dir / "rio_window" / "test_window.tif"
+    geojson_path = test_data_dir / "rio_window" / f"window_utm_{geojson_index}.geojson"
 
     df = gpd.read_file(geojson_path)
     extent = list(df.total_bounds)
@@ -121,16 +109,13 @@ def test_get_window_obj_utm(test_data_dir, geojson_index, array, transform):
     with rasterio.open(raster_path) as ds:
         src_profile = ds.profile
 
-    window = get_window_from_extent(src_profile,
-                                    extent,
-                                    crs
-                                    )
+    window = get_window_from_extent(src_profile, extent, crs)
     with rasterio.open(raster_path) as ds:
         window_transform = ds.window_transform(window=window)
 
     window_bounds = get_window_bounds(window, window_transform)
     window_geo = box(*window_bounds)
-    extent_raster_crs = df.to_crs(src_profile['crs']).total_bounds
+    extent_raster_crs = df.to_crs(src_profile["crs"]).total_bounds
     extent_geo = box(*extent_raster_crs)
     # The extent geometry goes beyond the actual image in the last case.
     extent_geo = extent_geo.intersection(window_geo)
@@ -148,17 +133,16 @@ Note we never go beyond UL corner specified by transform.
 """
 
 indices = [
-            ((0, 0), (11, 11)),  # ((row_start, col_start), (row_stop, col_stop))
-            ((0, 0), (10, 10)),
-            ((1, 1), (9, 9)),
-            ((2, 2), (8, 8)),
-          ]
+    ((0, 0), (11, 11)),  # ((row_start, col_start), (row_stop, col_stop))
+    ((0, 0), (10, 10)),
+    ((1, 1), (9, 9)),
+    ((2, 2), (8, 8)),
+]
 
 
 @pytest.mark.parametrize("extent, arr_index", zip(extents, indices))
 def test_get_indices(extent, arr_index):
-    """Verifying the get indices for windowed reading returns correct window
-    """
+    """Verifying the get indices for windowed reading returns correct window"""
     t = Affine(1, 0, 10, 0, -1, 0)
     ul, br = get_indices_from_extent(t, extent)
     assert arr_index == (ul, br)
@@ -166,17 +150,16 @@ def test_get_indices(extent, arr_index):
 
 # Indices
 indices_buffer = [
-                  ((0, 0), (12, 12)),  # ((row_start, col_start), (row_stop, col_stop))
-                  ((0, 0), (11, 11)),
-                  ((0, 0), (10, 10)),
-                  ((1, 1), (9, 9)),
-                  ]
+    ((0, 0), (12, 12)),  # ((row_start, col_start), (row_stop, col_stop))
+    ((0, 0), (11, 11)),
+    ((0, 0), (10, 10)),
+    ((1, 1), (9, 9)),
+]
 
 
 @pytest.mark.parametrize("extent, arr_index", zip(extents, indices_buffer))
 def test_get_indices_buffered(extent, arr_index):
-    """Make sure that windowed extents work correctly with 1 resolution buffer
-    """
+    """Make sure that windowed extents work correctly with 1 resolution buffer"""
     t = Affine(1, 0, 10, 0, -1, 0)
     ul, br = get_indices_from_extent(t, extent, res_buffer=1)
     assert arr_index == (ul, br)
@@ -184,17 +167,16 @@ def test_get_indices_buffered(extent, arr_index):
 
 # Indices
 indices_shape = [
-                  ((0, 0), (12, 10)),
-                  ((0, 0), (11, 10)),
-                  ((0, 0), (10, 10)),
-                  ((1, 1), (9, 9)),
-                  ]
+    ((0, 0), (12, 10)),
+    ((0, 0), (11, 10)),
+    ((0, 0), (10, 10)),
+    ((1, 1), (9, 9)),
+]
 
 
 @pytest.mark.parametrize("extent, arr_index", zip(extents, indices_shape))
 def test_get_indices_shape(extent, arr_index):
-    """Similar test using shape to truncate row_stop and col_stop
-    """
+    """Similar test using shape to truncate row_stop and col_stop"""
     t = Affine(1, 0, 10, 0, -1, 0)
     ul, br = get_indices_from_extent(t, extent, res_buffer=1, shape=(12, 10))
     assert arr_index == (ul, br)
@@ -206,99 +188,80 @@ def test_get_indices_shape(extent, arr_index):
 # shape is now (4, 5) = (height, width)
 
 extents_2 = [
-              [9.5, -4.5, 15.5, .5],     # beyond the reference image extent by .5 degrees
-              [10.5, -3.5, 14.5, -.5],   # .5 degree within reference image
-              [11.5, -2.5, 13.5, -1.5],  # 1.5 degree within reference image
-              [10.5, -5, 15, -.5],       # .5 degree on left and top
-              [11.5, -5, 15, -1.5],      # 1.5 degree on left and top
-             ]
+    [9.5, -4.5, 15.5, 0.5],  # beyond the reference image extent by .5 degrees
+    [10.5, -3.5, 14.5, -0.5],  # .5 degree within reference image
+    [11.5, -2.5, 13.5, -1.5],  # 1.5 degree within reference image
+    [10.5, -5, 15, -0.5],  # .5 degree on left and top
+    [11.5, -5, 15, -1.5],  # 1.5 degree on left and top
+]
 
 ref_2 = np.zeros((4, 5))
 ref_2[1:-1, 1:-1] = 1
-arrays_2 = [ref_2,
-            ref_2,
-            ref_2[1:-1, 1:-1],
-            ref_2,
-            ref_2[1:, 1:]
-            ]
+arrays_2 = [ref_2, ref_2, ref_2[1:-1, 1:-1], ref_2, ref_2[1:, 1:]]
 
 # Using upper left corner (10, 0) because (0, 0) raises warnings being the identify affine transformation
 t = Affine(1, 0, 10, 0, -1, 0)
-transforms_2 = [t,                           # reference transform
-                t,                           # reference transform
-                t.translation(1, -1) * t,    # transform with UL corner at (, -1)
-                t,                           # reference transform
-                t.translation(1, -1) * t]    # trasnform with UL corner at (12, -1)
+transforms_2 = [
+    t,  # reference transform
+    t,  # reference transform
+    t.translation(1, -1) * t,  # transform with UL corner at (, -1)
+    t,  # reference transform
+    t.translation(1, -1) * t,
+]  # trasnform with UL corner at (12, -1)
 
 
 @pytest.mark.parametrize("extent, array, transform", zip(extents_2, arrays_2, transforms_2))
 def test_read_window_4326_unequal_dims(test_data_dir, extent, array, transform):
-    raster_path = test_data_dir / 'rio_window' / 'test_window_unequal_dim.tif'
+    raster_path = test_data_dir / "rio_window" / "test_window_unequal_dim.tif"
 
-    window_arr, p = read_raster_from_window(raster_path,
-                                            extent,
-                                            CRS.from_epsg(4326),
-                                            res_buffer=0)
+    window_arr, p = read_raster_from_window(raster_path, extent, CRS.from_epsg(4326), res_buffer=0)
     array = array[np.newaxis, ...]
     assert_array_equal(array, window_arr)
-    assert transform == p['transform']
+    assert transform == p["transform"]
 
 
 # The dummy data is a 100 x 200 (.25 deg resolution) raster with origin at
 # (0, 0). So it's bounds are [0, -25, 50, 0] (xmin, ymin, xmax, ymax)
 bad_extents = [
-                # intersection along left of
-                # box i.e. line from (0, 0) to (0, -25)
-                [-10, -25, 0, 0],
-                # intersection along top of box i.e. from (0, 0) to
-                # (50, 0)
-                [0, 0, 50, 10]
-              ]
+    # intersection along left of
+    # box i.e. line from (0, 0) to (0, -25)
+    [-10, -25, 0, 0],
+    # intersection along top of box i.e. from (0, 0) to
+    # (50, 0)
+    [0, 0, 50, 10],
+]
 
 
 @pytest.mark.parametrize("bad_extent", bad_extents)
 def test_rio_window_exception(test_data_dir, bad_extent):
-    raster_path = test_data_dir / 'rio_window' / 'warning_exception_data.tif'
+    raster_path = test_data_dir / "rio_window" / "warning_exception_data.tif"
     with pytest.raises(RuntimeError):
-        X, p = read_raster_from_window(raster_path,
-                                       bad_extent,
-                                       CRS.from_epsg(4326),
-                                       res_buffer=0)
+        X, p = read_raster_from_window(raster_path, bad_extent, CRS.from_epsg(4326), res_buffer=0)
 
 
 # The dummy data is a 100 x 200 (.25 deg resolution) raster with origin at
 # (0, 0). So it's bounds are [0, -25, 50, 0] (xmin, ymin, xmax, ymax)
-warn_extents = [
-                [-1, -27, 1, -23],
-                [49, -1, 51, 1]
-                ]
+warn_extents = [[-1, -27, 1, -23], [49, -1, 51, 1]]
 
 
 @pytest.mark.parametrize("warn_extent", warn_extents)
 def test_rio_window_warning(test_data_dir, warn_extent):
-    raster_path = test_data_dir / 'rio_window' / 'warning_exception_data.tif'
+    raster_path = test_data_dir / "rio_window" / "warning_exception_data.tif"
     with pytest.warns(RuntimeWarning):
-        X, p = read_raster_from_window(raster_path,
-                                       warn_extent,
-                                       CRS.from_epsg(4326),
-                                       res_buffer=0)
+        X, p = read_raster_from_window(raster_path, warn_extent, CRS.from_epsg(4326), res_buffer=0)
 
 
 def test_riow_window_get_one_pixel(test_data_dir):
-    raster_path = test_data_dir / 'rio_window' / 'warning_exception_data.tif'
-    X, p = read_raster_from_window(raster_path,
-                                   [0, -25, 0.01, -24.999],
-                                   CRS.from_epsg(4326),
-                                   res_buffer=0)
+    raster_path = test_data_dir / "rio_window" / "warning_exception_data.tif"
+    X, p = read_raster_from_window(raster_path, [0, -25, 0.01, -24.999], CRS.from_epsg(4326), res_buffer=0)
     assert X.shape == (1, 1, 1)
-    assert p['width'] == p['height']
-    assert p['width'] == 1
+    assert p["width"] == p["height"]
+    assert p["width"] == 1
 
 
 def test_bad_extents_for_window():
     with pytest.raises(RuntimeError):
-        '''Outside of Geoid Bounds'''
+        """Outside of Geoid Bounds"""
         bounds = [-180, 34, -179, 35]
 
-        X, p = read_geoid('geoid_18',
-                          bounds)
+        X, p = read_geoid("geoid_18", bounds)


### PR DESCRIPTION
* Multithreading for windowed reading during merge operation
* Add 3.12 support
* Introduce ruffformatting - i.e. add ruff workflow to actions for static analysis and reformat python files.
* Provide separate progress bar for opening dataset, reading tile metadata, and reading tile array.
* Supresses: `RuntimeWarning: invalid value encountered in intersection` from `shapely`