### PR TITLE
Python 3.9 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           environment-name: dem-stitcher
           environment-file: environment.yml
-          extra-specs: |
+          create-args: >-
             python=${{ matrix.python-version }}
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0]
+
+## Fixed
+* 3.9 compatibility due to 3.10+ type hints.
+* Fixes the github action for tests to correctly use python versions specified by the matrix
+
+## Changed
+* Removes `|` in type hints for 3.9 compatibility.
+
 ## [2.5.9]
 
 ## Added

--- a/src/dem_stitcher/geoid.py
+++ b/src/dem_stitcher/geoid.py
@@ -1,5 +1,6 @@
 import warnings
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import rasterio
@@ -40,7 +41,7 @@ def get_geoid_path(geoid_short_name: str) -> Path:
     return geoid_path
 
 
-def get_default_geoid_path(dem_name: str | Path) -> Path:
+def get_default_geoid_path(dem_name: Union[str, Path]) -> Path:
     if dem_name not in DEM2GEOID.keys():
         raise ValueError(f'DEM name {dem_name} does not have a default geoid.')
     geoid_name = DEM2GEOID[dem_name]
@@ -48,7 +49,7 @@ def get_default_geoid_path(dem_name: str | Path) -> Path:
     return geoid_path
 
 
-def validate_geoid_path(geoid_path: str | Path) -> None:
+def validate_geoid_path(geoid_path: Union[str, Path]) -> None:
     if isinstance(geoid_path, str):
         if geoid_path in DEM2GEOID.values():
             return
@@ -65,7 +66,7 @@ def validate_geoid_path(geoid_path: str | Path) -> None:
     raise TypeError(f'Geoid path {geoid_path} is not of type str or Path.')
 
 
-def read_geoid(geoid_path: str | Path, extent: list | None = None, res_buffer: int = 1) -> tuple:
+def read_geoid(geoid_path: Union[str, Path], extent: Union[list, None] = None, res_buffer: int = 1) -> tuple:
     if extent is None:
         with rasterio.open(geoid_path) as ds:
             geoid_arr = ds.read()
@@ -109,7 +110,11 @@ def read_geoid(geoid_path: str | Path, extent: list | None = None, res_buffer: i
 
 
 def remove_geoid(
-    dem_arr: np.ndarray, dem_profile: dict, geoid_path: str | Path, dem_area_or_point: str = 'Area', res_buffer: int = 2
+    dem_arr: np.ndarray,
+    dem_profile: dict,
+    geoid_path: Union[str, Path],
+    dem_area_or_point: str = 'Area',
+    res_buffer: int = 2,
 ) -> np.ndarray:
     assert dem_area_or_point in ['Point', 'Area']
 

--- a/src/dem_stitcher/stitcher.py
+++ b/src/dem_stitcher/stitcher.py
@@ -167,7 +167,7 @@ def merge_and_transform_dem_tiles(
     num_threads_reproj: int = 5,
     merge_nodata_value: float = np.nan,
     n_threads_for_reading_tile_data: int = 5,
-    geoid_path: str | Path | None = None,
+    geoid_path: Union[str, Path, None] = None,
 ) -> tuple[np.ndarray, dict]:
     dem_arr, dem_profile = merge_tile_datasets_within_extent(
         datasets, bounds, nodata=merge_nodata_value, dtype=np.float32, n_threads=n_threads_for_reading_tile_data
@@ -257,7 +257,7 @@ def stitch_dem(
     n_threads_downloading: int = 10,
     fill_in_glo_30: bool = True,
     merge_nodata_value: float = np.nan,
-    geoid_path: str | Path = None,
+    geoid_path: Union[str, Path] = None,
 ) -> tuple[np.ndarray, dict]:
     """Specify extents (xmin, ymin, xmax, ymax) to obtain a continuous DEM raster.
 


### PR DESCRIPTION
* Updates the github action for tests to correctly use python versions specified by the matrix
* Removes `|` in type hints for 3.9 compatibility.