### PR TITLE
v2.5.12

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.15.0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.13.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.14.0

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.15.0

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.13.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.14.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.15.0
     with:
       release_prefix: dem-stitcher
       develop_branch: dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.13.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.14.0
     with:
       release_prefix: dem-stitcher
       develop_branch: dev

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.15.0
   
   call-ruff-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.15.0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.13.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.14.0
   
   call-ruff-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.13.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.14.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.15.0
     with:
       user: access-cloud-insar-team
       email: access-cloud-insar-team@jpl.nasa.gov

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.13.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.14.0
     with:
       user: access-cloud-insar-team
       email: access-cloud-insar-team@jpl.nasa.gov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.12] - 2025-01-29
+
+## Fixed
+* Ruff linting and formatting
+* In-memory merge of files - preserving nodata and dtypes correctly
+
+## Added
+* Tests for in-memory merge
+* Tests for crop profile
+
+## Removed
+* Dependency of environment.yml on anaconda and default distributions (now only `conda-forge`). This is purely ascethetic as the package's highest priority channel is `conda-forge`.
+
+
 ## [2.5.11]
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Added
 * Tests for in-memory merge
 * Tests for crop profile
+* Allows users to specify `dst_tile_dir` for location of tiles
+* Allows users to specify `overwrite_existing_tiles` for overwriting existing tiles (should tiles need to be re-used in the same directory)
 
 ## Removed
 * Dependency of environment.yml on anaconda and default distributions (now only `conda-forge`). This is purely ascethetic as the package's highest priority channel is `conda-forge`.
@@ -58,7 +60,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.5.8]
 ### Fixed
-* Resolves read_geoid issue [here](https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/issues/96). 
+* Resolves read_geoid issue [here](https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/issues/96).
   * Update geoid url for egm08 (again) creating public bucket for ACCESS processing
   * Included egm96 as gtx in the data directory
   * egm08 and egm96 data comes from here: https://download.osgeo.org/proj/vdatum/
@@ -70,7 +72,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   * when no credentials in netrc are present when requesting data for `nasadem` or `srtm_v3`, there is a human readable error instructing user to update their `~/.netrc`.
 * Updates some ruff linting
   * Ensures ruff in `environment.yml`
-  * Ensure single quotes for consistency. 
+  * Ensure single quotes for consistency.
 ### Changed
 * egm08 is now using 2.5 deg raster rather than 1 deg.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,6 @@
 name: dem-stitcher
 channels:
  - conda-forge
- - anaconda
- - defaults
 dependencies:
  - python>=3.9
  - pip

--- a/notebooks/Merging_DEM_Tiles_into_a_VRT.ipynb
+++ b/notebooks/Merging_DEM_Tiles_into_a_VRT.ipynb
@@ -105,6 +105,16 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "83668b32-8376-444f-a6a0-32acf578b2e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vsicurl_paths = [f'/vsicurl/{url}' for url in dem_tile_paths]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "f4848969",
    "metadata": {
     "ExecuteTime": {
@@ -119,17 +129,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "3d642224",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-03-23T22:44:39.119320Z",
-     "start_time": "2023-03-23T22:43:29.984396Z"
+   "execution_count": 7,
+   "id": "d9971b0d-21ed-4f6d-8205-74a4704949a0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/cmarshak/miniforge3/envs/dem-stitcher/lib/python3.12/site-packages/osgeo/gdal.py:312: FutureWarning: Neither gdal.UseExceptions() nor gdal.DontUseExceptions() has been explicitly called. In GDAL 4.0, exceptions will be enabled by default.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 218 ms, sys: 915 ms, total: 1.13 s\n",
+      "Wall time: 33.2 s\n"
+     ]
     }
-   },
-   "outputs": [],
+   ],
    "source": [
+    "%%time\n",
+    "\n",
     "ds = gdal.BuildVRT(vrt_path, dem_tile_paths)\n",
+    "ds = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d26b7777-9fac-4c78-94b4-25a3e0c2b038",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 13.6 ms, sys: 6.98 ms, total: 20.6 ms\n",
+      "Wall time: 11.6 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "ds = gdal.BuildVRT(vrt_path, vsicurl_paths)\n",
     "ds = None"
    ]
   },
@@ -143,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "03cdc596",
    "metadata": {
     "ExecuteTime": {
@@ -158,7 +204,7 @@
        "BoundingBox(left=-122.00013888888888, bottom=34.00013888888889, right=-120.00013888888888, top=37.00013888888889)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -186,7 +232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/src/dem_stitcher/datasets.py
+++ b/src/dem_stitcher/datasets.py
@@ -83,7 +83,7 @@ def get_overlapping_dem_tiles(bounds: list, dem_name: str) -> gpd.GeoDataFrame:
     if crossing:
         warn(
             'Getting tiles across dateline on the opposite hemisphere; '
-            f'The source tiles will be {- 2 * crossing} deg along the'
+            f'The source tiles will be {-2 * crossing} deg along the'
             'longitudinal axis from the extent requested',
             category=UserWarning,
         )

--- a/src/dem_stitcher/merge.py
+++ b/src/dem_stitcher/merge.py
@@ -89,13 +89,43 @@ def merge_arrays_with_geometadata(
     arrays: list[np.ndarray],
     profiles: list[dict],
     resampling: str = 'bilinear',
-    nodata: Union[float, int] = np.nan,
+    nodata: float = None,
     dtype: str = None,
     method: str = 'first',
 ) -> tuple[np.ndarray, dict]:
+    """Merge arrays in memory with geometadata.
+
+    Parameters
+    ----------
+    arrays : list[np.ndarray]
+        Arrays to merge (must be in the same CRS)
+    profiles : list[dict]
+        Geometadata for each array
+    resampling : str, optional
+        See acceptable values rasterio.enums.Resampling, by default 'bilinear'
+    nodata : float, optional
+        Nodata value to be inserted into merged profile. If None, uses the nodata value from the first profile,
+        by default None
+    dtype : str, optional
+        Dtype to be inserted into merged profile. If None, uses the dtype from the first profile, by default None
+    method : str, optional
+        See acceptable values in rasterio.merge.merge, by default 'first'
+
+    Returns
+    -------
+    tuple[np.ndarray, dict]
+        Merged array and profile
+
+    Raises
+    ------
+    ValueError
+        * If arrays are not in BIP format
+        * If arrays have different number of dimensions (i.e. 2 or 3)
+        * If number of profiles is not the same as number of arrays
+    """
     n_dim = arrays[0].shape
     if len(n_dim) not in [2, 3]:
-        raise ValueError('Currently arrays must be in BIP format' 'i.e. channels x height x width or flat array')
+        raise ValueError('Currently arrays must be in BIP formati.e. channels x height x width or flat array')
     if len(set([len(arr.shape) for arr in arrays])) != 1:
         raise ValueError('All arrays must have same number of dimensions i.e. 2 or 3')
 
@@ -111,8 +141,18 @@ def merge_arrays_with_geometadata(
     datasets = [mfile.open(**p) for (mfile, p) in zip(memfiles, profiles)]
     [ds.write(arr) for (ds, arr) in zip(datasets, arrays_input)]
 
+    if dtype is None:
+        dst_dtype = profiles[0]['dtype']
+    else:
+        dst_dtype = dtype
+
+    if nodata is None:
+        dst_nodata = profiles[0]['nodata']
+    else:
+        dst_nodata = nodata
+
     merged_arr, merged_trans = merge(
-        datasets, resampling=Resampling[resampling], method=method, nodata=nodata, dtype=dtype
+        datasets, resampling=Resampling[resampling], method=method, nodata=dst_nodata, dtype=dst_dtype
     )
 
     prof_merged = profiles[0].copy()
@@ -120,10 +160,8 @@ def merge_arrays_with_geometadata(
     prof_merged['count'] = merged_arr.shape[0]
     prof_merged['height'] = merged_arr.shape[1]
     prof_merged['width'] = merged_arr.shape[2]
-    if nodata is not None:
-        prof_merged['nodata'] = nodata
-    if nodata is not None:
-        prof_merged['dtype'] = dtype
+    prof_merged['nodata'] = dst_nodata
+    prof_merged['dtype'] = dst_dtype
 
     [ds.close() for ds in datasets]
     [mfile.close() for mfile in memfiles]

--- a/src/dem_stitcher/rio_window.py
+++ b/src/dem_stitcher/rio_window.py
@@ -136,7 +136,7 @@ def get_window_from_extent(
 
     if intersection_geo.geom_type != 'Polygon':
         raise RuntimeError(
-            'The intersection geometry is degenerate (i.e. a ' f'Point or LineString: {intersection_geo.geom_type}'
+            f'The intersection geometry is degenerate (i.e. a Point or LineString: {intersection_geo.geom_type}'
         )
     if not intersection_geo.is_empty:
         window_extent_r = intersection_geo.bounds
@@ -147,7 +147,7 @@ def get_window_from_extent(
                 category=RuntimeWarning,
             )
     else:
-        raise RuntimeError('The extent you specified does not overlap' ' the specified raster as a Polygon.')
+        raise RuntimeError('The extent you specified does not overlap the specified raster as a Polygon.')
 
     corner_ul, corner_br = get_indices_from_extent(
         src_profile['transform'], window_extent_r, shape=src_shape, res_buffer=res_buffer

--- a/src/dem_stitcher/stitcher.py
+++ b/src/dem_stitcher/stitcher.py
@@ -54,7 +54,13 @@ def _download_and_write_one_tile_to_gtiff(url: str, dest_path: Path, reader: Cal
     return dem_profile
 
 
-def download_tiles_to_gtiff(urls: list, dem_name: str, dest_dir: Path, max_workers_for_download: int = 5) -> list[Path]:
+def download_tiles_to_gtiff(
+    urls: list,
+    dem_name: str,
+    dest_dir: Path,
+    max_workers_for_download: int = 5,
+    overwrite_existing_tiles: bool = False,
+) -> list[Path]:
     tile_ids = list(map(lambda x: x.split('/')[-1], urls))
 
     def extract_dest_path_from_url(tile_id: str) -> Path:
@@ -73,12 +79,16 @@ def download_tiles_to_gtiff(urls: list, dem_name: str, dest_dir: Path, max_worke
     def download_and_write_one_partial(zipped_data: list) -> dict:
         return _download_and_write_one_tile_to_gtiff(zipped_data[0], zipped_data[1], reader, dem_name)
 
-    data_list = zip(urls, dest_paths)
+    # filter non existing destination path
+    if not overwrite_existing_tiles:
+        data_list = [(u, d) for u, d in zip(urls, dest_paths) if not d.exists()]
+    else:
+        data_list = list(zip(urls, dest_paths))
     with ThreadPoolExecutor(max_workers=max_workers_for_download) as executor:
         list(
             tqdm(
                 executor.map(download_and_write_one_partial, data_list),
-                total=len(urls),
+                total=len(data_list),
                 desc=f'Downloading {dem_name} tiles',
             )
         )
@@ -92,7 +102,8 @@ def get_dem_tile_paths(
     dem_name: str,
     localize_tiles_to_gtiff: bool = False,
     n_threads_downloading: int = 5,
-    tile_dir: Union[str, Path] = None,
+    tile_dir: Union[str, Path, None] = None,
+    overwrite_existing_tiles: bool = False,
 ) -> list[str]:
     """Obtain paths or urls to DEM tiles.
 
@@ -115,6 +126,8 @@ def get_dem_tile_paths(
         Number of workers for downloading, by default 5
     tile_dir : Path | str, optional
         Directory to localize files, by default None, which saves to `dem_name`.
+    overwrite_existing_tiles : bool, optional
+        If True, overwrite existing tiles, by default False
 
     Returns
     -------
@@ -139,7 +152,13 @@ def get_dem_tile_paths(
         if tile_dir.exists():
             warn(f'The directory{tile_dir} exists; We are writing new files to this directory', category=UserWarning)
         tile_dir.mkdir(exist_ok=True, parents=True)
-        dem_paths = download_tiles_to_gtiff(urls, dem_name, tile_dir, max_workers_for_download=n_threads_downloading)
+        dem_paths = download_tiles_to_gtiff(
+            urls,
+            dem_name,
+            tile_dir,
+            max_workers_for_download=n_threads_downloading,
+            overwrite_existing_tiles=overwrite_existing_tiles,
+        )
     return dem_paths
 
 
@@ -258,6 +277,8 @@ def stitch_dem(
     fill_in_glo_30: bool = True,
     merge_nodata_value: float = np.nan,
     geoid_path: Union[str, Path] = None,
+    dst_tile_dir: Union[Path, str, None] = None,
+    overwrite_existing_tiles: bool = False,
 ) -> tuple[np.ndarray, dict]:
     """Specify extents (xmin, ymin, xmax, ymax) to obtain a continuous DEM raster.
 
@@ -290,6 +311,10 @@ def stitch_dem(
         When set to 0 and not converting to ellipsoidal heights, all nodata areas will be 0.
     geoid_path: str | Path, optional
         Path to geoid file. If None, then the default geoid is used.
+    dst_tile_dir: Path | str, optional
+        If not None do not remove tiles already downloaded, and use them instead of downloading.
+    overwrite_existing_tiles: bool, optional
+        If True, overwrite existing tiles, by default False
 
     Returns
     -------
@@ -320,17 +345,17 @@ def stitch_dem(
 
     # Random unique identifier
     tmp_id = str(uuid.uuid4())
-    tile_dir = Path(f'tmp_{tmp_id}')
+    tile_dir = dst_tile_dir or Path(f'tmp_{tmp_id}')
 
     if dem_name in ['srtm_v3', 'nasadem']:
         ensure_earthdata_credentials()
-
     dem_paths = get_dem_tile_paths(
         bounds=bounds,
         dem_name=dem_name,
-        localize_tiles_to_gtiff=False,
+        localize_tiles_to_gtiff=dst_tile_dir is not None,
         n_threads_downloading=n_threads_downloading,
         tile_dir=tile_dir,
+        overwrite_existing_tiles=overwrite_existing_tiles,
     )
 
     # Opening is capped at 5 threads because more leads to errors
@@ -379,7 +404,7 @@ def stitch_dem(
     list(map(lambda dataset: dataset.close(), datasets))
 
     # Delete orginal tiles if downloaded
-    if tile_dir.exists():
+    if tile_dir.exists() and dst_tile_dir is None:
         shutil.rmtree(str(tile_dir))
 
     # Created in memory file containers if there is a dateline crossing for translation

--- a/src/dem_stitcher/stitcher.py
+++ b/src/dem_stitcher/stitcher.py
@@ -137,7 +137,7 @@ def get_dem_tile_paths(
         if tile_dir is None:
             tile_dir = Path(dem_name)
         if tile_dir.exists():
-            warn(f'The directory{tile_dir} exists; ' 'We are writing new files to this directory', category=UserWarning)
+            warn(f'The directory{tile_dir} exists; We are writing new files to this directory', category=UserWarning)
         tile_dir.mkdir(exist_ok=True, parents=True)
         dem_paths = download_tiles_to_gtiff(urls, dem_name, tile_dir, max_workers_for_download=n_threads_downloading)
     return dem_paths


### PR DESCRIPTION
* in-memory merge updates (ensuring properly formatted profile)
* `get_cropped_profile` to allow obtain a profile from numpy slices
* `dst_tile_dir` (and allowing for tiles to be cached if re-using the function via `overwrite_existing_tiles`)