### PR TITLE
refactor merge_and_transform_dem_tiles to combine operations

### DIFF
--- a/src/dem_stitcher/stitcher.py
+++ b/src/dem_stitcher/stitcher.py
@@ -21,7 +21,7 @@ from .geoid import get_default_geoid_path, remove_geoid, validate_geoid_path
 from .merge import merge_arrays_with_geometadata, merge_tile_datasets_within_extent
 from .rio_tools import (
     reproject_arr_to_match_profile,
-    reproject_arr_to_new_crs,
+    reproject_profile_to_new_crs,
     translate_dataset,
     translate_profile,
     update_profile_resolution,
@@ -41,6 +41,8 @@ PIXEL_CENTER_DEMS = ['srtm_v3', 'nasadem', 'glo_30', 'glo_90', 'glo_90_missing']
 DEFAULT_GTIFF_PROFILE = default_gtiff_profile.copy()
 DEFAULT_GTIFF_PROFILE.pop('nodata')
 DEFAULT_GTIFF_PROFILE.pop('dtype')
+EPSG_4269 = CRS.from_epsg(4269)
+EPSG_4326 = CRS.from_epsg(4326)
 
 
 def _download_and_write_one_tile_to_gtiff(url: str, dest_path: Path, reader: Callable, dem_name: str) -> dict:
@@ -176,6 +178,20 @@ def shift_profile_for_pixel_loc(src_profile: dict, src_area_or_point: str, dst_a
     return profile_shifted
 
 
+def _build_target_profile(src_profile: dict, dst_resolution: Union[float, tuple[float], None]) -> dict:
+    dst_profile = src_profile.copy()
+
+    # Reproject to 4326 for USGS DEMs over North America
+    # (Note 4269 is almost identical to 4326 and often no changes are made)
+    if dst_profile['crs'] == EPSG_4269:
+        dst_profile = reproject_profile_to_new_crs(dst_profile, EPSG_4326)
+
+    if dst_resolution is not None:
+        dst_profile = update_profile_resolution(dst_profile, dst_resolution)
+
+    return dst_profile
+
+
 def merge_and_transform_dem_tiles(
     datasets: list,
     bounds: list,
@@ -191,21 +207,17 @@ def merge_and_transform_dem_tiles(
     dem_arr, dem_profile = merge_tile_datasets_within_extent(
         datasets, bounds, nodata=merge_nodata_value, dtype=np.float32, n_threads=n_threads_for_reading_tile_data
     )
-    # We could have merge_nodata_value that is zero and we want the final metadata
-    # to be np.nan
-    dem_profile['nodata'] = np.nan
-    src_area_or_point = datasets[0].tags().get('AREA_OR_POINT', 'Area')
-
-    dem_profile = shift_profile_for_pixel_loc(dem_profile, src_area_or_point, dst_area_or_point)
-
-    # Reproject to 4326 for USGS DEMs over North America
-    # Note 4269 is almost identical to 4326 and often no changes are made
-    if dem_profile['crs'] == CRS.from_epsg(4269):
-        dem_arr, dem_profile = reproject_arr_to_new_crs(dem_arr, dem_profile, CRS.from_epsg(4326))
-
-    if dem_profile['crs'] != CRS.from_epsg(4326):
+    if dem_profile['crs'] not in (EPSG_4269, EPSG_4326):
         raise ValueError('CRS must be epsg 4269 or 4326')
 
+    # We could have merge_nodata_value that is zero and we want the final metadata
+    # to be np.nan.
+    dem_profile['nodata'] = np.nan
+    src_area_or_point = datasets[0].tags().get('AREA_OR_POINT', 'Area')
+    dem_profile = shift_profile_for_pixel_loc(dem_profile, src_area_or_point, dst_area_or_point)
+
+    # Geoid removal before resampling. The normal resample is to increase the grid to match the
+    # finer dimension.
     if dst_ellipsoidal_height:
         if geoid_path is None:
             geoid_path = get_default_geoid_path(dem_name)
@@ -216,10 +228,15 @@ def merge_and_transform_dem_tiles(
             dem_area_or_point=dst_area_or_point,
         )
 
-    if dst_resolution is not None:
-        dem_profile_res = update_profile_resolution(dem_profile, dst_resolution)
+    # CRS reproject and resolution change in a single warp
+    target_profile = _build_target_profile(dem_profile, dst_resolution)
+    if dem_profile != target_profile:
         dem_arr, dem_profile = reproject_arr_to_match_profile(
-            dem_arr, dem_profile, dem_profile_res, num_threads=num_threads_reproj, resampling='bilinear'
+            dem_arr,
+            dem_profile,
+            target_profile,
+            num_threads=num_threads_reproj,
+            resampling='bilinear',
         )
 
     # Ensure dem_arr has correct shape

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -1,5 +1,7 @@
+import shutil
+import subprocess
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Union
 
 import numpy as np
 import pytest
@@ -8,6 +10,8 @@ from affine import Affine
 from numpy.testing import assert_allclose, assert_almost_equal, assert_array_equal
 from osgeo import gdal
 from rasterio import default_gtiff_profile
+from rasterio.crs import CRS
+from rasterio.io import MemoryFile
 from shapely.geometry import box
 
 from dem_stitcher import get_dem_tile_paths, stitch_dem
@@ -86,6 +90,120 @@ def test_no_change_when_no_transformations_to_tile(
     tile_data = X_tile[~mask]
 
     assert_array_equal(subset_data, tile_data)
+
+
+def _make_memory_dem_dataset_4269() -> tuple[MemoryFile, rasterio.DatasetReader, list[float]]:
+    profile = default_gtiff_profile.copy()
+    profile.update(
+        {
+            'dtype': np.float32,
+            'count': 1,
+            'height': 64,
+            'width': 64,
+            'crs': CRS.from_epsg(4269),
+            'transform': Affine(1.0 / 3600.0, 0, -120, 0, -(1.0 / 3600.0), 35),
+            'nodata': np.nan,
+        }
+    )
+    arr = np.arange(64 * 64, dtype=np.float32).reshape(64, 64)
+    memfile = MemoryFile()
+    dataset = memfile.open(**profile)
+    dataset.write(arr[None, ...])
+    dataset.update_tags(AREA_OR_POINT='Area')
+    bounds = [-119.998, 34.985, -119.985, 34.998]
+    return memfile, dataset, bounds
+
+
+@pytest.mark.parametrize(
+    'dst_resolution, expected_res_xy',
+    [
+        (0.0005, (0.0005, 0.0005)),
+        ((0.0005, 0.00075), (0.0005, 0.00075)),
+    ],
+)
+def test_output_profile_matches_requested_crs_and_resolution_for_4269_input(
+    dst_resolution: Union[float, tuple[float, float]], expected_res_xy: tuple[float, float]
+) -> None:
+    memfile, dataset, bounds = _make_memory_dem_dataset_4269()
+    try:
+        dem_arr, dem_profile = merge_and_transform_dem_tiles(
+            datasets=[dataset],
+            bounds=bounds,
+            dem_name='3dep',
+            dst_ellipsoidal_height=False,
+            dst_area_or_point='Area',
+            dst_resolution=dst_resolution,
+        )
+    finally:
+        dataset.close()
+        memfile.close()
+
+    assert dem_arr.shape[0] == 1
+    assert dem_profile['crs'] == CRS.from_epsg(4326)
+    assert dem_profile['transform'].a == expected_res_xy[0]
+    assert abs(dem_profile['transform'].e) == expected_res_xy[1]
+
+
+def test_4269_reprojection_branch_matches_rio_warp(tmp_path: Path) -> None:
+    src_path = tmp_path / 'src_4269.tif'
+    expected_path = tmp_path / 'expected_4326.tif'
+    rio = shutil.which('rio')
+    if rio is None:
+        pytest.skip('rio CLI is required for this test')
+
+    memfile, dataset, _ = _make_memory_dem_dataset_4269()
+    try:
+        with rasterio.open(src_path, 'w', **dataset.profile) as src_ds:
+            src_ds.write(dataset.read())
+            src_ds.update_tags(**dataset.tags())
+    finally:
+        dataset.close()
+        memfile.close()
+
+    subprocess.run(
+        [
+            rio,
+            'warp',
+            str(src_path),
+            str(expected_path),
+            '--dst-crs',
+            'EPSG:4326',
+            '--resampling',
+            'bilinear',
+            '--threads',
+            '1',
+            '--overwrite',
+        ],
+        check=True,
+    )
+
+    with rasterio.open(src_path) as src_ds:
+        bounds = [
+            src_ds.bounds.left,
+            src_ds.bounds.bottom,
+            src_ds.bounds.right,
+            src_ds.bounds.top,
+        ]
+        dem_arr, dem_profile = merge_and_transform_dem_tiles(
+            datasets=[src_ds],
+            bounds=bounds,
+            dem_name='3dep',
+            dst_ellipsoidal_height=False,
+            dst_area_or_point='Area',
+            dst_resolution=None,
+            num_threads_reproj=1,
+            n_threads_for_reading_tile_data=1,
+        )
+
+    with rasterio.open(expected_path) as expected_ds:
+        expected_arr = expected_ds.read()
+        expected_profile = expected_ds.profile
+
+    assert dem_profile['crs'] == expected_profile['crs']
+    assert dem_profile['transform'] == expected_profile['transform']
+    assert dem_profile['width'] == expected_profile['width']
+    assert dem_profile['height'] == expected_profile['height']
+    assert_allclose(dem_arr, expected_arr, equal_nan=True, atol=1e-6)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Closes #143 

Previously merge_and_transform_dem_tiles potentially had two operations performed on the DEM data in two separate reproject_arr_to_match_profile calls. This combines the two into one for performance reasons.

Also, only one used the num_threads_reproj before, so this compounds the speedup by doing the single operation with num_threads_reproj.

<!--
If this is a pull request for a new release, please use the release template:
   {{ cookiecutter.public_url }}/compare/main...develop?template=release.md
 
If this PR does not include changes that should be reflected in CHANGELOG.md,
please indicate so by affixing the `bumpless` label to this PR.

NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->