### PR TITLE
reproject functions preserve source dtype

### DIFF
--- a/src/dem_stitcher/rio_tools.py
+++ b/src/dem_stitcher/rio_tools.py
@@ -123,7 +123,7 @@ def reproject_arr_to_match_profile(
     reproject_profile.update({'dtype': src_dtype, 'nodata': nodata, 'count': count})
 
     height, width = ref_profile['height'], ref_profile['width']
-    dst_array = np.zeros((count, height, width))
+    dst_array = np.zeros((count, height, width), dtype=src_dtype)
 
     reproject(
         src_array,
@@ -136,7 +136,7 @@ def reproject_arr_to_match_profile(
         resampling=Resampling[resampling],
         num_threads=num_threads,
     )
-    return dst_array.astype(src_dtype), reproject_profile
+    return dst_array, reproject_profile
 
 
 def get_bounds_dict(profile: dict) -> dict:
@@ -234,7 +234,10 @@ def reproject_arr_to_new_crs(
     tr = target_resolution
     reprojected_profile = reproject_profile_to_new_crs(src_profile, dst_crs, target_resolution=tr)
     resampling = Resampling[resampling]
-    dst_array = np.zeros((reprojected_profile['count'], reprojected_profile['height'], reprojected_profile['width']))
+    dst_array = np.zeros(
+        (reprojected_profile['count'], reprojected_profile['height'], reprojected_profile['width']),
+        dtype=src_profile['dtype'],
+    )
 
     reproject(
         # Source parameters

--- a/tests/test_rio_tools.py
+++ b/tests/test_rio_tools.py
@@ -1,9 +1,16 @@
 from pathlib import Path
 
+import numpy as np
 import rasterio
 from numpy.testing import assert_almost_equal
+from rasterio.crs import CRS
 
-from dem_stitcher.rio_tools import reproject_arr_to_match_profile, translate_dataset, update_profile_resolution
+from dem_stitcher.rio_tools import (
+    reproject_arr_to_match_profile,
+    reproject_arr_to_new_crs,
+    translate_dataset,
+    update_profile_resolution,
+)
 
 
 def test_update_resolution(test_data_dir: Path) -> None:
@@ -33,6 +40,7 @@ def test_update_resolution(test_data_dir: Path) -> None:
 
     assert_almost_equal(X_quarter_deg_reprj, X_quarter_deg, 5)
     assert t_quarter_deg == p_higher_res['transform']
+    assert X_quarter_deg_reprj.dtype == np.float32
 
 
 def test_dataset_translation(test_data_dir: Path) -> None:
@@ -52,3 +60,19 @@ def test_dataset_translation(test_data_dir: Path) -> None:
     ds_left_t.close()
     ds_right.close()
     mfile.close()
+
+
+def test_reproject_to_new_crs_preserves_dtype(test_data_dir: Path) -> None:
+    """reproject_arr_to_new_crs should return an array matching the source dtype."""
+    data_dir = test_data_dir / 'rio_tools' / 'update_resolution'
+    with rasterio.open(data_dir / 'res_one_deg.tif') as ds:
+        src_profile = ds.profile
+        src_arr = ds.read()
+
+    assert src_profile['dtype'] == 'float32'
+
+    # UTM zone 32N covers the test tile's location (lon 10-12, lat -2 to 0)
+    result_arr, _ = reproject_arr_to_new_crs(
+        src_arr, src_profile, CRS.from_epsg(32632), resampling='bilinear'
+    )
+    assert result_arr.dtype == np.float32


### PR DESCRIPTION
Closes #145

reproject_arr_to_match_profile allocated a float64 destination array then copied it back with .astype(src_dtype): we can get rid of the middleman.

reproject_arr_to_new_crs allocated float64 regardless of input dtype.

Changes both to allocate np.zeros with dtype=src_dtype from the start.